### PR TITLE
feat: add shared-memory skill for cross-project/cross-team memory

### DIFF
--- a/skills/shared-memory/SKILL.md
+++ b/skills/shared-memory/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: shared-memory
+description: Cross-project SQLite+FTS5 memory shared between multiple Claude Code installations. Complements the file-based `memory` skill with searchable long-term store and cross-team handoffs.
+auto_activate: false
+---
+
+# metaswarm Shared Memory
+
+Cross-project, cross-team memory backed by SQLite+FTS5. Complements the
+file-based `memory` skill — use it when you need:
+
+- Memory that survives across projects, machines, or team rotations
+- Full-text search across past learnings
+- Cross-team handoffs (team-1 → team-2 etc.)
+- Lease-based task coordination (prevents two teams grabbing the same issue)
+
+Everything is single-file SQLite at `~/.claude/shared-memory/learnings.db` with
+WAL mode. No server, no daemon.
+
+## Installation
+
+```bash
+# 1. Install the store library
+cp lib/store.js ~/.claude/shared-memory/lib/store.js
+
+# 2. Install CLIs
+cp bin/memory ~/bin/memory
+cp bin/handoff ~/bin/handoff
+cp bin/agent-team ~/bin/agent-team
+chmod +x ~/bin/memory ~/bin/handoff ~/bin/agent-team
+
+# 3. Install SessionStart hook (optional, surfaces memory at session start)
+cp hooks/session-start-memory.js ~/.claude/hooks/session-start-memory.js
+# then register in ~/.claude/settings.json under "SessionStart"
+```
+
+Requires `better-sqlite3` somewhere on the node path (the lib probes common
+install locations automatically).
+
+## CLI Reference
+
+### memory — put/find/recent
+
+```bash
+memory put --scope global|project:<name> --type semantic|episodic|procedural \
+           --title "..." --body "..." [--tags t1,t2] [--key stable-key]
+memory find "<query>" [--scope X] [--type X] [--limit N]
+memory recent [--limit 10]
+memory show <id-or-key>
+```
+
+### handoff — structured cross-team handoffs
+
+```bash
+handoff send --to team-1 --title "..." --phase qa --summary "..." \
+             --locked "path1,path2" --next "step1|step2"
+handoff inbox [--team team-1]
+handoff show <id>
+handoff ack <id>
+```
+
+### agent-team — lease-based task coordination
+
+```bash
+agent-team claim AGE-123 [--for 60] [--as team-2] [--note "..."]
+agent-team release AGE-123
+agent-team list [--team team-1]
+agent-team expire
+agent-team status
+```
+
+## Schema
+
+- `scope`: `global` or `project:<name>`
+- `type`:
+  - `semantic` — stable facts (who owns what, current architecture)
+  - `episodic` — events with timestamps (handoffs, leases, incidents)
+  - `procedural` — rules ("never use PowerShell for Danish text")
+- `tags`: comma-separated, free-form
+- FTS5 index covers `title`, `body`, `tags`
+
+## When to Use vs. File-Based `memory`
+
+| Use-case | Skill |
+|----------|-------|
+| Project-local state, active task | `memory` (markdown files) |
+| Cross-project learnings, facts | `shared-memory` |
+| Handoffs between teams | `shared-memory` (handoff CLI) |
+| Task claim/lease coordination | `shared-memory` (agent-team CLI) |
+| Full-text search across history | `shared-memory` |
+
+Both can run side-by-side — they do not conflict.

--- a/skills/shared-memory/bin/agent-team
+++ b/skills/shared-memory/bin/agent-team
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+// agent-team — native primitives for multi-team coordination (Q3)
+//
+// Provides lightweight, file-backed primitives on top of shared-memory:
+//   - claim/release  : lease-based task claiming (prevents two teams grabbing same issue)
+//   - list           : active leases with TTL
+//   - expire         : purge expired leases
+//   - status         : who is on what, where
+//
+// Leases are stored as global episodic entries keyed `lease:<issue>`.
+// Each lease has an expires_at; the next `list` or `claim` auto-expires stale ones.
+//
+// Usage:
+//   agent-team claim AGE-123 [--for 60] [--as team-2] [--note "..."]
+//   agent-team release AGE-123
+//   agent-team list [--team team-1] [--all]
+//   agent-team expire
+//   agent-team status
+
+'use strict';
+
+const path = require('path');
+const LIB = process.env.SHARED_MEMORY_LIB || path.resolve(process.env.HOME, '.claude/shared-memory/lib');
+const store = require(path.join(LIB, 'store.js'));
+
+function parseArgs(argv) {
+  const a = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const x = argv[i];
+    if (x.startsWith('--')) {
+      const k = x.slice(2); const n = argv[i + 1];
+      if (n === undefined || n.startsWith('--')) a[k] = true;
+      else { a[k] = n; i++; }
+    } else a._.push(x);
+  }
+  return a;
+}
+
+function resolveTeam() {
+  if (process.env.SS_SYNC_TEAM) return process.env.SS_SYNC_TEAM;
+  try {
+    const cfg = require(path.resolve(process.env.HOME, '.skrivstore/lib/config.js'));
+    return cfg.resolveTeamAndProject().team;
+  } catch (_) { return 'team-unknown'; }
+}
+
+function die(msg) { process.stderr.write(`agent-team: ${msg}\n`); process.exit(1); }
+
+function allLeases() {
+  return store.search({ query: 'lease', scopes: ['global'], types: ['episodic'], limit: 500 })
+    .filter((e) => e.key && e.key.startsWith('lease:'));
+}
+
+function parseLease(e) {
+  try { return { e, b: JSON.parse(e.body) }; } catch { return null; }
+}
+
+function isExpired(lease) {
+  return lease.b.expires_at && Date.now() > lease.b.expires_at;
+}
+
+function issueFromArgs(args) {
+  const issue = args._[0];
+  if (!issue) die('issue id required (e.g. AGE-123 or path/to/file)');
+  return issue;
+}
+
+function cmd_claim(args) {
+  const issue = issueFromArgs(args);
+  const team = args.as || resolveTeam();
+  const minutes = args.for ? Number(args.for) : 60;
+  const key = `lease:${issue}`;
+
+  const existing = store.get({ scope: 'global', key });
+  if (existing) {
+    const lease = parseLease(existing);
+    if (lease && !isExpired(lease) && lease.b.team !== team) {
+      die(`already claimed by ${lease.b.team} until ${new Date(lease.b.expires_at).toISOString()} (use --as ${lease.b.team} to extend, or wait)`);
+    }
+  }
+
+  const body = {
+    issue,
+    team,
+    note: args.note || '',
+    claimed_at: Date.now(),
+    expires_at: Date.now() + minutes * 60000,
+    renewed: existing ? ((parseLease(existing)?.b.renewed || 0) + 1) : 0,
+  };
+
+  store.put({
+    scope: 'global', type: 'episodic', key,
+    title: `[lease ${team}] ${issue}`,
+    body: JSON.stringify(body, null, 2),
+    tags: ['lease', team, issue],
+    team, source: 'agent-team',
+  });
+  console.log(`claimed ${issue} for ${team}, expires ${new Date(body.expires_at).toISOString()}`);
+}
+
+function cmd_release(args) {
+  const issue = issueFromArgs(args);
+  const team = args.as || resolveTeam();
+  const key = `lease:${issue}`;
+  const e = store.get({ scope: 'global', key });
+  if (!e) die(`no lease on ${issue}`);
+  const lease = parseLease(e);
+  if (lease && lease.b.team !== team && !args.force) {
+    die(`lease owned by ${lease.b.team}, not ${team} (use --force to override)`);
+  }
+  // Mark as released by expiring immediately. Preserves history.
+  const body = { ...(lease?.b || {}), released_at: Date.now(), expires_at: Date.now() - 1 };
+  store.put({
+    scope: 'global', type: 'episodic', key,
+    title: `[lease released ${team}] ${issue}`,
+    body: JSON.stringify(body, null, 2),
+    tags: ['lease', 'released', team, issue],
+    team, source: 'agent-team',
+  });
+  console.log(`released ${issue}`);
+}
+
+function cmd_list(args) {
+  const leases = allLeases().map(parseLease).filter(Boolean);
+  const now = Date.now();
+  const filtered = leases.filter((l) => {
+    if (args.team && l.b.team !== args.team) return false;
+    if (!args.all && isExpired(l)) return false;
+    return true;
+  });
+  if (!filtered.length) { console.log('(no active leases)'); return; }
+  for (const l of filtered) {
+    const mins = Math.round((l.b.expires_at - now) / 60000);
+    const status = isExpired(l) ? 'EXPIRED' : `${mins}m left`;
+    const released = l.b.released_at ? ' (released)' : '';
+    console.log(`  ${l.b.issue.padEnd(24)} ${l.b.team.padEnd(10)} ${status}${released}${l.b.note ? ' — ' + l.b.note : ''}`);
+  }
+}
+
+function cmd_expire() {
+  const leases = allLeases().map(parseLease).filter(Boolean);
+  let n = 0;
+  for (const l of leases) {
+    if (!isExpired(l)) continue;
+    if (l.b.expired_tombstoned) continue;
+    const body = { ...l.b, expired_tombstoned: Date.now() };
+    store.put({
+      scope: 'global', type: 'episodic', key: l.e.key,
+      title: `[lease expired ${l.b.team}] ${l.b.issue}`,
+      body: JSON.stringify(body, null, 2),
+      tags: ['lease', 'expired', l.b.team, l.b.issue],
+      team: l.b.team, source: 'agent-team',
+    });
+    n++;
+  }
+  console.log(`tombstoned ${n} expired lease(s)`);
+}
+
+function cmd_status() {
+  const team = resolveTeam();
+  const active = allLeases().map(parseLease).filter(Boolean).filter((l) => !isExpired(l));
+  const mine = active.filter((l) => l.b.team === team);
+  const others = active.filter((l) => l.b.team !== team);
+
+  console.log(`team: ${team}`);
+  console.log(`my leases: ${mine.length}`);
+  for (const l of mine) {
+    const mins = Math.round((l.b.expires_at - Date.now()) / 60000);
+    console.log(`  ${l.b.issue} (${mins}m left)${l.b.note ? ' — ' + l.b.note : ''}`);
+  }
+  console.log(`other teams: ${others.length}`);
+  for (const l of others) {
+    const mins = Math.round((l.b.expires_at - Date.now()) / 60000);
+    console.log(`  ${l.b.issue} by ${l.b.team} (${mins}m left)`);
+  }
+}
+
+function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  const args = parseArgs(rest);
+  switch (cmd) {
+    case 'claim':   return cmd_claim(args);
+    case 'release': return cmd_release(args);
+    case 'list':    return cmd_list(args);
+    case 'expire':  return cmd_expire();
+    case 'status':  return cmd_status();
+    case 'help': case '--help': case '-h': case undefined:
+      return console.log(`agent-team - native primitives for multi-team coordination
+
+Commands:
+  claim <issue> [--for <min>] [--as <team>] [--note "..."]
+                              Acquire a lease on an issue (default 60 min)
+  release <issue> [--force]   Release a lease (force to override other-team locks)
+  list [--team X] [--all]     Show active leases (or all including expired)
+  expire                      Tombstone expired leases
+  status                      Summary of your team's leases and others
+
+Leases stored as global episodic entries in shared-memory (key=lease:<issue>).
+Integrates with handoff and memory CLIs.`);
+    default: die(`unknown command: ${cmd}`);
+  }
+}
+
+try { main(); } catch (e) { die(e.stack || e.message); }

--- a/skills/shared-memory/bin/handoff
+++ b/skills/shared-memory/bin/handoff
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// Structured cross-team handoff.
+// Stores handoff records as episodic entries in shared-memory (scope=global, key=handoff:<id>),
+// so the target team sees them on SessionStart and in the panel.
+//
+// Usage:
+//   handoff send --to team-1|team-2 --title "..." [--phase planning|building|qa|review|done]
+//                [--summary "..."] [--locked "path1,path2"] [--next "step1|step2"]
+//                [--issue <id>] [--project <name>]
+//   handoff inbox [--team team-1|team-2] [--limit 10]
+//   handoff show <handoff-id>
+//   handoff ack  <handoff-id>   (marks as read for receiving team)
+
+const path = require('path');
+const LIB = process.env.SHARED_MEMORY_LIB || path.resolve(process.env.HOME, '.claude/shared-memory/lib');
+const store = require(path.join(LIB, 'store.js'));
+
+function parseArgs(argv) {
+  const a = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const x = argv[i];
+    if (x.startsWith('--')) {
+      const k = x.slice(2); const n = argv[i + 1];
+      if (n === undefined || n.startsWith('--')) a[k] = true;
+      else { a[k] = n; i++; }
+    } else a._.push(x);
+  }
+  return a;
+}
+
+function resolveTeam() {
+  if (process.env.SS_SYNC_TEAM) return process.env.SS_SYNC_TEAM;
+  try {
+    const cfg = require(path.resolve(process.env.HOME, '.skrivstore/lib/config.js'));
+    return cfg.resolveTeamAndProject().team;
+  } catch (_) { return 'team-unknown'; }
+}
+
+function cmd_send(args) {
+  if (!args.to) die('--to required (team-1|team-2)');
+  if (!args.title) die('--title required');
+  const from = resolveTeam();
+  const id = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`;
+  const key = `handoff:${id}`;
+  const locked = typeof args.locked === 'string'
+    ? args.locked.split(',').map((s) => s.trim()).filter(Boolean) : [];
+  const next = typeof args.next === 'string'
+    ? args.next.split('|').map((s) => s.trim()).filter(Boolean) : [];
+
+  const body = {
+    from,
+    to: args.to,
+    phase: args.phase || 'handoff',
+    issue: args.issue || null,
+    project: args.project || null,
+    summary: args.summary || '',
+    locked_files: locked,
+    next_steps: next,
+    ack: false,
+    created_at: new Date().toISOString(),
+  };
+
+  store.put({
+    scope: 'global',
+    type: 'episodic',
+    key,
+    title: `[handoff ${from}→${args.to}] ${args.title}`,
+    body: JSON.stringify(body, null, 2),
+    tags: ['handoff', from, args.to, ...(args.phase ? [args.phase] : [])],
+    team: from,
+    source: 'handoff',
+  });
+  console.log(`sent ${key} (${from} → ${args.to})`);
+}
+
+function allHandoffs() {
+  return store.search({ query: 'handoff', scopes: ['global'], types: ['episodic'], limit: 200 })
+    .filter((e) => e.key && e.key.startsWith('handoff:'));
+}
+
+function cmd_inbox(args) {
+  const target = args.team || resolveTeam();
+  const limit = args.limit ? Number(args.limit) : 10;
+  const rows = allHandoffs()
+    .map((e) => { try { return { e, b: JSON.parse(e.body) }; } catch { return null; } })
+    .filter((x) => x && x.b.to === target)
+    .slice(0, limit);
+  if (!rows.length) { console.log(`(no handoffs for ${target})`); return; }
+  for (const { e, b } of rows) {
+    const age = Math.round((Date.now() - e.updated_at) / 60000);
+    console.log(`${e.key}  ${b.ack ? '✓' : '○'}  ${b.from}→${b.to}  ${age}m  phase=${b.phase}`);
+    console.log(`  ${e.title.replace(/^\[handoff [^\]]+\]\s*/, '')}`);
+    if (b.summary) console.log(`  summary: ${b.summary.slice(0, 160)}`);
+    if (b.locked_files?.length) console.log(`  locked:  ${b.locked_files.join(', ')}`);
+    if (b.next_steps?.length) console.log(`  next:    ${b.next_steps.map((s) => '• ' + s).join('  ')}`);
+    console.log('');
+  }
+}
+
+function cmd_show(args) {
+  const hid = args._[0];
+  if (!hid) die('show <handoff-id>');
+  const key = hid.startsWith('handoff:') ? hid : `handoff:${hid}`;
+  const e = store.get({ scope: 'global', key });
+  if (!e) die(`not found: ${key}`);
+  console.log(e.title);
+  console.log(e.body);
+}
+
+function cmd_ack(args) {
+  const hid = args._[0];
+  if (!hid) die('ack <handoff-id>');
+  const key = hid.startsWith('handoff:') ? hid : `handoff:${hid}`;
+  const e = store.get({ scope: 'global', key });
+  if (!e) die(`not found: ${key}`);
+  let b; try { b = JSON.parse(e.body); } catch { die('corrupt handoff body'); }
+  b.ack = true; b.acked_at = new Date().toISOString(); b.acked_by = resolveTeam();
+  store.put({
+    scope: 'global', type: 'episodic', key,
+    title: e.title, body: JSON.stringify(b, null, 2),
+    tags: (e.tags || '').split(',').filter(Boolean),
+    team: e.team, source: 'handoff-ack',
+  });
+  console.log(`acked ${key}`);
+}
+
+function die(msg) { process.stderr.write(`handoff: ${msg}\n`); process.exit(1); }
+
+function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  const args = parseArgs(rest);
+  switch (cmd) {
+    case 'send':  return cmd_send(args);
+    case 'inbox': return cmd_inbox(args);
+    case 'show':  return cmd_show(args);
+    case 'ack':   return cmd_ack(args);
+    case 'help': case '--help': case '-h': case undefined:
+      return console.log(`handoff - structured cross-team handoff (via shared-memory)
+
+Commands:
+  send --to <team> --title "..." [--phase p] [--summary "..."]
+       [--locked "path,path"] [--next "step1|step2"] [--issue id] [--project p]
+  inbox [--team team-1|team-2] [--limit 10]
+  show  <handoff-id>
+  ack   <handoff-id>
+`);
+    default: die(`unknown command: ${cmd}`);
+  }
+}
+
+try { main(); } catch (e) { die(e.stack || e.message); }

--- a/skills/shared-memory/bin/memory
+++ b/skills/shared-memory/bin/memory
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// Shared cross-project memory CLI.
+// Usage:
+//   memory put   --type <semantic|episodic|procedural> --title "..." [--body "..."] [--scope global|project:<name>] [--key <k>] [--tags a,b] [--team team-1|team-2] [--pinned]
+//   memory get   (--id <n> | --scope <s> --key <k>)
+//   memory find  "<query>" [--scope <s>] [--type <t>] [--limit 20] [--json]
+//   memory recent [--scope <s>] [--limit 10] [--json]
+//   memory archive <id>
+//   memory stats [--json]
+
+const path = require('path');
+const LIB = process.env.SHARED_MEMORY_LIB || path.resolve(process.env.HOME, '.claude/shared-memory/lib');
+const store = require(path.join(LIB, 'store.js'));
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a.startsWith('--')) {
+      const k = a.slice(2);
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith('--')) { args[k] = true; }
+      else { args[k] = next; i++; }
+    } else {
+      args._.push(a);
+    }
+  }
+  return args;
+}
+
+function out(obj, json) {
+  if (json) { console.log(JSON.stringify(obj, null, 2)); return; }
+  if (Array.isArray(obj)) { obj.forEach((e) => printEntry(e)); return; }
+  printEntry(obj);
+}
+
+function printEntry(e) {
+  if (!e) { console.log('(none)'); return; }
+  const age = e.updated_at ? Math.round((Date.now() - e.updated_at) / 60000) + 'm ago' : '';
+  console.log(`#${e.id} [${e.type}] ${e.scope} ${e.pinned ? '★ ' : ''}${age}`);
+  if (e.key) console.log(`  key: ${e.key}`);
+  console.log(`  title: ${e.title}`);
+  if (e.body) console.log(`  body:  ${e.body.split('\n').join('\n         ')}`);
+  if (e.tags) console.log(`  tags:  ${e.tags}`);
+  if (e.team) console.log(`  team:  ${e.team}`);
+  console.log('');
+}
+
+function resolveTeam() {
+  if (process.env.SS_SYNC_TEAM) return process.env.SS_SYNC_TEAM;
+  try {
+    const cfg = require(path.resolve(process.env.HOME, '.skrivstore/lib/config.js'));
+    return cfg.resolveTeamAndProject().team;
+  } catch (_) { return null; }
+}
+
+function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+  const args = parseArgs(rest);
+
+  switch (cmd) {
+    case 'put': {
+      if (!args.type) die('--type required (semantic|episodic|procedural)');
+      if (!args.title) die('--title required');
+      const r = store.put({
+        scope: args.scope || 'global',
+        type: args.type,
+        key: args.key || null,
+        title: args.title,
+        body: args.body || '',
+        tags: typeof args.tags === 'string' ? args.tags.split(',').map((s) => s.trim()).filter(Boolean) : [],
+        team: args.team || resolveTeam(),
+        source: args.source || 'cli',
+        pinned: !!args.pinned,
+      });
+      if (args.json) { console.log(JSON.stringify(r, null, 2)); }
+      else { console.log(`${r.updated ? 'updated' : 'created'} #${r.id}`); }
+      break;
+    }
+    case 'get': {
+      const r = store.get({ id: args.id ? Number(args.id) : null, scope: args.scope || null, key: args.key || null });
+      out(r, !!args.json);
+      break;
+    }
+    case 'find':
+    case 'search': {
+      const query = args._[0] || args.query || '';
+      const scopes = args.scope ? String(args.scope).split(',') : null;
+      const types = args.type ? String(args.type).split(',') : null;
+      const limit = args.limit ? Number(args.limit) : 20;
+      const r = store.search({ query, scopes, types, limit });
+      out(r, !!args.json);
+      break;
+    }
+    case 'recent': {
+      const r = store.recent({ scope: args.scope || null, limit: args.limit ? Number(args.limit) : 10 });
+      out(r, !!args.json);
+      break;
+    }
+    case 'archive': {
+      const id = Number(args._[0]);
+      if (!id) die('archive <id> required');
+      const r = store.archive(id);
+      if (args.json) console.log(JSON.stringify(r));
+      else console.log(r.ok ? `archived #${id}` : `not found: #${id}`);
+      break;
+    }
+    case 'stats': {
+      const s = store.stats();
+      if (args.json) { console.log(JSON.stringify(s, null, 2)); break; }
+      console.log(`db:    ${s.dbPath}`);
+      console.log(`total: ${s.total}`);
+      console.log('by type:');  s.byType.forEach((r) => console.log(`  ${r.type.padEnd(12)} ${r.n}`));
+      console.log('by scope:'); s.byScope.forEach((r) => console.log(`  ${r.scope.padEnd(24)} ${r.n}`));
+      break;
+    }
+    case 'where': {
+      console.log(store.DB_PATH);
+      break;
+    }
+    case 'help':
+    case '--help':
+    case '-h':
+    case undefined:
+      printHelp(); break;
+    default:
+      die(`unknown command: ${cmd}`);
+  }
+}
+
+function die(msg) {
+  process.stderr.write(`memory: ${msg}\n`);
+  process.exit(1);
+}
+
+function printHelp() {
+  console.log(`memory - shared cross-project memory
+
+Commands:
+  put --type <t> --title "..." [--body "..."] [--scope <s>] [--key <k>]
+      [--tags a,b] [--team <t>] [--pinned] [--source <s>]
+  get (--id <n> | --scope <s> --key <k>)
+  find "<query>" [--scope <s>] [--type <t>] [--limit 20] [--json]
+  recent [--scope <s>] [--limit 10] [--json]
+  archive <id>
+  stats [--json]
+  where            # print DB path
+
+Scopes:    global (default), project:<name>
+Types:     semantic | episodic | procedural
+DB:        ~/.claude/shared-memory/learnings.db (FTS5 enabled)
+`);
+}
+
+try { main(); } catch (e) {
+  process.stderr.write(`memory: ${e.stack || e.message}\n`);
+  process.exit(1);
+}

--- a/skills/shared-memory/hooks/session-start-memory.js
+++ b/skills/shared-memory/hooks/session-start-memory.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// SessionStart hook — inject recent shared-memory entries into the session context.
+//
+// Reads pinned + recent semantic/procedural entries from ~/.claude/shared-memory/learnings.db
+// and emits them as additionalContext on stdout per Claude Code hook protocol.
+//
+// Keeps output small (≤ ~1.5KB) so it never dominates context. Honors SS_MEMORY_DISABLE=1.
+
+const path = require('path');
+
+function emit(additionalContext) {
+  // Claude Code SessionStart protocol: JSON with additionalContext string.
+  try {
+    process.stdout.write(JSON.stringify({ hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext } }));
+  } catch (_) {}
+  process.exit(0);
+}
+
+if (process.env.SS_MEMORY_DISABLE === '1') emit('');
+
+let store;
+try {
+  const lib = process.env.SHARED_MEMORY_LIB || path.resolve(process.env.HOME, '.claude/shared-memory/lib');
+  store = require(path.join(lib, 'store.js'));
+} catch (e) {
+  process.stderr.write(`[session-start-memory] store unavailable: ${e.message}\n`);
+  emit('');
+}
+
+// Pull: top 3 pinned, top 5 recent procedural, top 5 recent semantic (global + current project).
+let project = null;
+try {
+  const cfg = require(path.resolve(process.env.HOME, '.skrivstore/lib/config.js'));
+  project = cfg.resolveTeamAndProject().project;
+} catch (_) {}
+
+const scopes = ['global'];
+if (project) scopes.push(`project:${project}`);
+
+function recentByType(type, limit) {
+  try {
+    return store.search({ query: '', scopes, types: [type], limit });
+  } catch (_) { return []; }
+}
+
+let procedural = recentByType('procedural', 5);
+let semantic = recentByType('semantic', 5);
+let episodic = recentByType('episodic', 3);
+
+// Pending handoffs addressed to current team
+let team = null;
+try {
+  team = process.env.SS_SYNC_TEAM || require(path.resolve(process.env.HOME, '.skrivstore/lib/config.js')).resolveTeamAndProject().team;
+} catch (_) {}
+let handoffs = [];
+try {
+  handoffs = store.search({ query: 'handoff', scopes: ['global'], types: ['episodic'], limit: 50 })
+    .filter((e) => e.key && e.key.startsWith('handoff:'))
+    .map((e) => { try { return { e, b: JSON.parse(e.body) }; } catch { return null; } })
+    .filter((x) => x && x.b.to === team && !x.b.ack)
+    .slice(0, 5);
+} catch (_) {}
+
+// Reflexion — surface top-K relevant gotchas for current work (Q5)
+// Scans ~/projects/skrivsikkert/.beads/knowledge/{gotchas,anti-patterns}.jsonl
+let reflexions = [];
+try {
+  const rxPath = path.resolve(process.env.HOME, 'projects/skrivsikkert/agent_ops/scripts/lib/reflexion.js');
+  if (require('fs').existsSync(rxPath)) {
+    const { Reflexion } = require(rxPath);
+    const rx = new Reflexion();
+    // Without a specific task prompt, surface critical-severity items
+    const all = [
+      ...rx._readJsonl('anti-patterns.jsonl'),
+      ...rx._readJsonl('gotchas.jsonl'),
+    ];
+    reflexions = all
+      .filter((r) => r.severity === 'critical')
+      .slice(-3);
+  }
+} catch (_) {}
+
+// Recent completions (last 48h) — what the other team or I shipped
+const projectBase = project ? path.basename(project) : null;
+let completions = [];
+try {
+  const since = Date.now() - 48 * 3600 * 1000;
+  completions = store.search({ query: 'completion', scopes: ['global'], types: ['episodic'], limit: 100 })
+    .filter((e) => e.key && e.key.startsWith('completion:') && e.updated_at >= since)
+    .map((e) => { try { return { e, b: JSON.parse(e.body) }; } catch { return null; } })
+    .filter(Boolean)
+    .filter((x) => {
+      if (!projectBase || !x.b.project) return true;
+      const bp = path.basename(x.b.project);
+      return bp === projectBase;
+    })
+    .slice(0, 5);
+} catch (_) {}
+
+function fmt(list) {
+  return list.map((e) => {
+    const b = (e.body || '').replace(/\s+/g, ' ').slice(0, 180);
+    return `- [${e.type}] ${e.title}${b ? ' — ' + b : ''}`;
+  }).join('\n');
+}
+
+const parts = [];
+if (handoffs.length) {
+  const lines = handoffs.map(({ e, b }) => {
+    const next = (b.next_steps || []).slice(0, 3).map((s) => '• ' + s).join('  ');
+    return `- ${e.key} (${b.from}→${b.to}, phase=${b.phase}): ${e.title.replace(/^\[handoff [^\]]+\]\s*/, '')}${b.summary ? ' — ' + b.summary.slice(0, 120) : ''}${next ? '\n  next: ' + next : ''}`;
+  }).join('\n');
+  parts.push('### Pending handoffs for you (run `handoff ack <id>` to clear)\n' + lines);
+}
+if (completions.length) {
+  const lines = completions.map(({ e, b }) => {
+    const tag = b.pr ? `PR#${b.pr}` : b.issue || '';
+    const age = Math.round((Date.now() - e.updated_at) / 60000);
+    const next = (b.next_steps || []).slice(0, 2).map((s) => '• ' + s).join('  ');
+    return `- [${b.team}${tag ? ' ' + tag : ''}, ${age}m ago, ${b.status}] ${e.title.replace(/^\[done [^\]]+\]\s*/, '')}${b.summary ? ' — ' + b.summary.slice(0, 100) : ''}${next ? '\n  next: ' + next : ''}`;
+  }).join('\n');
+  parts.push('### Recently shipped (last 48h)\n' + lines);
+}
+if (reflexions.length) {
+  const lines = reflexions.map((r) => {
+    const head = r.type === 'gotcha' ? r.heads_up : r.rule;
+    const files = r.files && r.files.length ? ' (files: ' + r.files.slice(0, 2).join(', ') + ')' : '';
+    return `- [${r.severity}] ${head}${files}`;
+  }).join('\n');
+  parts.push('### Critical gotchas from prior failures (Reflexion)\n' + lines);
+}
+if (procedural.length) parts.push('### Shared rules\n' + fmt(procedural));
+if (semantic.length)   parts.push('### Shared facts\n' + fmt(semantic));
+// exclude handoff and completion episodic entries (they're shown above)
+episodic = episodic.filter((e) => !(e.key && (e.key.startsWith('handoff:') || e.key.startsWith('completion:'))));
+if (episodic.length)   parts.push('### Recent incidents\n' + fmt(episodic));
+
+if (!parts.length) emit('');
+
+const ctx = [
+  '## Shared cross-project memory',
+  `(~/bin/memory find "<query>" for more; DB: ${store.DB_PATH})`,
+  '',
+  parts.join('\n\n'),
+].join('\n');
+
+// Cap at 3KB to accommodate completions + handoffs + rules
+const CAP = 3072;
+emit(ctx.length > CAP ? ctx.slice(0, CAP) + '\n…(truncated)' : ctx);

--- a/skills/shared-memory/lib/store.js
+++ b/skills/shared-memory/lib/store.js
@@ -1,0 +1,154 @@
+// Shared cross-project memory store.
+// SQLite-backed. Namespaces: project:<name>, global.
+// Types: semantic (facts), episodic (incidents with timestamp), procedural (rules).
+//
+// Consumers: ~/bin/memory CLI, panel API routes, SessionStart hook.
+const path = require('path');
+const fs = require('fs');
+
+const SHARED_HOME = process.env.SHARED_MEMORY_HOME || path.resolve(process.env.HOME, '.claude/shared-memory');
+const DB_PATH = path.join(SHARED_HOME, 'learnings.db');
+
+// Reuse better-sqlite3 from the panel install (it's there; standalone CLI path)
+function resolveBetterSqlite() {
+  const candidates = [
+    path.resolve(process.env.HOME, '.skrivstore-panel/node_modules/better-sqlite3'),
+    path.resolve(process.env.HOME, '.skrivstore/node_modules/better-sqlite3'),
+  ];
+  for (const p of candidates) {
+    try { return require(p); } catch (_) {}
+  }
+  try { return require('better-sqlite3'); } catch (_) {}
+  throw new Error('better-sqlite3 not found. Run: cd ~/.skrivstore-panel && npm install');
+}
+
+let _db = null;
+function getDb() {
+  if (_db) return _db;
+  fs.mkdirSync(SHARED_HOME, { recursive: true });
+  const Database = resolveBetterSqlite();
+  _db = new Database(DB_PATH);
+  _db.pragma('journal_mode = WAL');
+  _db.pragma('synchronous = NORMAL');
+  _db.exec(`
+    CREATE TABLE IF NOT EXISTS entry (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      scope TEXT NOT NULL,            -- 'project:<name>' or 'global'
+      type TEXT NOT NULL,             -- semantic | episodic | procedural
+      key TEXT,                       -- optional stable key for upsert
+      title TEXT NOT NULL,
+      body TEXT NOT NULL,
+      tags TEXT,                      -- comma-separated
+      team TEXT,                      -- team-1 | team-2 | (null)
+      source TEXT,                    -- agent | cli | hook | panel
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      pinned INTEGER NOT NULL DEFAULT 0,
+      archived INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_entry_scope ON entry(scope, archived);
+    CREATE INDEX IF NOT EXISTS idx_entry_type ON entry(type, archived);
+    CREATE INDEX IF NOT EXISTS idx_entry_key ON entry(scope, key) WHERE key IS NOT NULL;
+    CREATE INDEX IF NOT EXISTS idx_entry_updated ON entry(updated_at DESC);
+    CREATE VIRTUAL TABLE IF NOT EXISTS entry_fts USING fts5(title, body, tags, content='entry', content_rowid='id');
+    CREATE TRIGGER IF NOT EXISTS entry_ai AFTER INSERT ON entry BEGIN
+      INSERT INTO entry_fts(rowid, title, body, tags) VALUES (new.id, new.title, new.body, new.tags);
+    END;
+    CREATE TRIGGER IF NOT EXISTS entry_ad AFTER DELETE ON entry BEGIN
+      INSERT INTO entry_fts(entry_fts, rowid, title, body, tags) VALUES('delete', old.id, old.title, old.body, old.tags);
+    END;
+    CREATE TRIGGER IF NOT EXISTS entry_au AFTER UPDATE ON entry BEGIN
+      INSERT INTO entry_fts(entry_fts, rowid, title, body, tags) VALUES('delete', old.id, old.title, old.body, old.tags);
+      INSERT INTO entry_fts(rowid, title, body, tags) VALUES (new.id, new.title, new.body, new.tags);
+    END;
+  `);
+  return _db;
+}
+
+function normalizeScope(s) {
+  if (!s) return 'global';
+  if (s === 'global') return 'global';
+  if (s.startsWith('project:')) return s;
+  return `project:${s}`;
+}
+
+function put({ scope = 'global', type, key = null, title, body = '', tags = [], team = null, source = 'cli', pinned = false }) {
+  if (!title) throw new Error('title required');
+  if (!['semantic', 'episodic', 'procedural'].includes(type)) throw new Error('type must be semantic|episodic|procedural');
+  const db = getDb();
+  const now = Date.now();
+  const tagStr = Array.isArray(tags) ? tags.join(',') : String(tags || '');
+  scope = normalizeScope(scope);
+
+  if (key) {
+    const existing = db.prepare('SELECT id FROM entry WHERE scope = ? AND key = ? AND archived = 0').get(scope, key);
+    if (existing) {
+      db.prepare(`UPDATE entry SET title=?, body=?, tags=?, team=COALESCE(?, team), source=?, updated_at=?, pinned=? WHERE id=?`)
+        .run(title, body, tagStr, team, source, now, pinned ? 1 : 0, existing.id);
+      return { ok: true, id: existing.id, updated: true };
+    }
+  }
+  const r = db.prepare(`INSERT INTO entry(scope,type,key,title,body,tags,team,source,created_at,updated_at,pinned)
+                         VALUES (?,?,?,?,?,?,?,?,?,?,?)`)
+    .run(scope, type, key, title, body, tagStr, team, source, now, now, pinned ? 1 : 0);
+  return { ok: true, id: r.lastInsertRowid, updated: false };
+}
+
+function get({ id = null, scope = null, key = null }) {
+  const db = getDb();
+  if (id) return db.prepare('SELECT * FROM entry WHERE id = ?').get(id);
+  if (scope && key) return db.prepare('SELECT * FROM entry WHERE scope = ? AND key = ? AND archived = 0').get(normalizeScope(scope), key);
+  return null;
+}
+
+function search({ query, scopes = null, types = null, limit = 20, includeArchived = false }) {
+  const db = getDb();
+  const clauses = [];
+  const params = [];
+
+  if (query && query.trim()) {
+    // Use FTS5. Quote to handle punctuation.
+    const safeQ = query.replace(/"/g, '""');
+    clauses.push('e.id IN (SELECT rowid FROM entry_fts WHERE entry_fts MATCH ?)');
+    params.push(`"${safeQ}"`);
+  }
+  if (Array.isArray(scopes) && scopes.length) {
+    clauses.push(`e.scope IN (${scopes.map(() => '?').join(',')})`);
+    scopes.forEach((s) => params.push(normalizeScope(s)));
+  }
+  if (Array.isArray(types) && types.length) {
+    clauses.push(`e.type IN (${types.map(() => '?').join(',')})`);
+    types.forEach((t) => params.push(t));
+  }
+  if (!includeArchived) clauses.push('e.archived = 0');
+
+  const where = clauses.length ? 'WHERE ' + clauses.join(' AND ') : '';
+  const sql = `SELECT e.* FROM entry e ${where} ORDER BY e.pinned DESC, e.updated_at DESC LIMIT ?`;
+  params.push(limit);
+  return db.prepare(sql).all(...params);
+}
+
+function recent({ scope = null, limit = 10 } = {}) {
+  const db = getDb();
+  if (scope) {
+    return db.prepare('SELECT * FROM entry WHERE scope = ? AND archived = 0 ORDER BY pinned DESC, updated_at DESC LIMIT ?')
+      .all(normalizeScope(scope), limit);
+  }
+  return db.prepare('SELECT * FROM entry WHERE archived = 0 ORDER BY pinned DESC, updated_at DESC LIMIT ?').all(limit);
+}
+
+function archive(id) {
+  const db = getDb();
+  const r = db.prepare('UPDATE entry SET archived = 1, updated_at = ? WHERE id = ?').run(Date.now(), id);
+  return { ok: r.changes === 1 };
+}
+
+function stats() {
+  const db = getDb();
+  const total = db.prepare('SELECT COUNT(*) AS n FROM entry WHERE archived = 0').get().n;
+  const byType = db.prepare('SELECT type, COUNT(*) AS n FROM entry WHERE archived = 0 GROUP BY type').all();
+  const byScope = db.prepare('SELECT scope, COUNT(*) AS n FROM entry WHERE archived = 0 GROUP BY scope').all();
+  return { total, byType, byScope, dbPath: DB_PATH };
+}
+
+module.exports = { put, get, search, recent, archive, stats, SHARED_HOME, DB_PATH };


### PR DESCRIPTION
## Summary

Adds a new `shared-memory` skill that provides cross-project, cross-team memory backed by SQLite+FTS5. Complements the existing file-based memory approaches with:

- **Cross-project searchable long-term store** — survives machine/team/session rotation
- **Full-text search (FTS5)** across past learnings, rules, and incidents
- **Cross-team handoffs** — structured episodic entries addressed team→team
- **Lease-based task coordination** — prevents two teams grabbing the same issue

All state lives in a single SQLite file (`~/.claude/shared-memory/learnings.db`, WAL mode) — no server, no daemon.

## What's included

| Component | Purpose |
|-----------|---------|
| `lib/store.js` | SQLite+FTS5 store with put/find/recent/stats API |
| `bin/memory` | CLI: put/find/recent/show |
| `bin/handoff` | CLI: send/inbox/show/ack structured handoffs |
| `bin/agent-team` | CLI: claim/release/list/expire/status leases |
| `hooks/session-start-memory.js` | SessionStart hook that surfaces recent entries + handoffs + completions into session context |

## When to use vs. the file-based `memory` approach

| Use-case | Skill |
|----------|-------|
| Project-local state, active task | file-based memory |
| Cross-project learnings, facts | shared-memory |
| Handoffs between teams | shared-memory (handoff CLI) |
| Task claim/lease coordination | shared-memory (agent-team CLI) |
| Full-text search across history | shared-memory |

Both can run side-by-side — they do not conflict.

## Test plan

- [x] Tested end-to-end on two independent Claude Code installations sharing the same `~/.claude/shared-memory` directory
- [x] Smoke tested: `memory put` / `memory find` / `memory recent`
- [x] Smoke tested: `handoff send` / `handoff inbox` / `handoff ack`
- [x] Smoke tested: `agent-team claim` / `release` / `list` / `expire` / `status`
- [x] SessionStart hook output verified under 3KB cap
- [x] FTS5 search across 140+ real entries

## Notes for maintainers

- The skill depends on `better-sqlite3` — the lib probes common install locations (panel, skrivstore) automatically so no hard dependency is introduced for the skill package itself
- Hook is opt-in — users register it in `~/.claude/settings.json` after copying
- `auto_activate: false` — users invoke explicitly, not every session

🤖 Generated with [Claude Code](https://claude.com/claude-code)