### PR TITLE
feat: /codex-plan-review and spec-gap-review skill (v0.12.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "metaswarm",
-  "version": "0.11.0",
-  "description": "Multi-agent orchestration framework for Claude Code, Gemini CLI, and Codex CLI — 19 agents, 13 skills, 15 commands, quality gates, TDD enforcement",
+  "version": "0.12.0",
+  "description": "Multi-agent orchestration framework for Claude Code, Gemini CLI, and Codex CLI — 19 agents, 14 skills, 16 commands, quality gates, TDD enforcement",
   "author": {
     "name": "David Sifry",
     "email": "david@sifry.com"

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,6 +1,6 @@
 # metaswarm for Codex CLI
 
-Install metaswarm's 13 orchestration skills for [Codex CLI](https://github.com/openai/codex).
+Install metaswarm's Codex skills for [Codex CLI](https://github.com/openai/codex).
 
 ## Install
 
@@ -14,11 +14,13 @@ curl -sSL https://raw.githubusercontent.com/dsifry/metaswarm/main/.codex/install
 
 ```bash
 git clone https://github.com/dsifry/metaswarm.git ~/.codex/metaswarm
-mkdir -p ~/.agents/skills
+mkdir -p ~/.codex/skills
 for d in ~/.codex/metaswarm/skills/*/; do
-  ln -sf "$d" ~/.agents/skills/metaswarm-$(basename "$d")
+  ln -sf "$d" ~/.codex/skills/$(basename "$d")
 done
 ```
+
+If `CODEX_HOME` is set, use `$CODEX_HOME` in place of `~/.codex`.
 
 ### Via npm (cross-platform installer)
 
@@ -38,7 +40,7 @@ This detects your project's language, framework, test runner, and tools, then cr
 
 ## How Codex Finds Skills
 
-Codex uses the `name` field from each skill's `SKILL.md` frontmatter — not the directory name. The directory prefix `metaswarm-` is for organization only. You invoke skills using `$name` syntax matching the SKILL.md `name` field.
+Codex uses the `name` field from each skill's `SKILL.md` frontmatter — not the directory name. metaswarm installs skills into `${CODEX_HOME:-$HOME/.codex}/skills/`, and you invoke them with `$name` syntax matching the `SKILL.md` frontmatter.
 
 ## Available Skills
 
@@ -53,6 +55,7 @@ Codex uses the `name` field from each skill's `SKILL.md` frontmatter — not the
 | `$pr-shepherd` | `pr-shepherd` | Monitor a PR through to merge |
 | `$handling-pr-comments` | `handling-pr-comments` | Handle PR review comments |
 | `$create-issue` | `create-issue` | Create a well-structured GitHub Issue |
+| `$spec-gap-review` | `spec-gap-review` | Audit a spec or design doc against repo reality |
 | `$external-tools` | `external-tools` | Check/use external AI tools |
 | `$status` | `status` | Run diagnostic checks |
 | `$migrate` | `migrate` | Migrate from npm installation |
@@ -80,7 +83,7 @@ Or re-run the install script — it detects existing installations and updates i
 
 ```bash
 # Remove skill symlinks
-for link in ~/.agents/skills/metaswarm-*; do rm -f "$link"; done
+for d in ~/.codex/metaswarm/skills/*/; do rm -f ~/.codex/skills/$(basename "$d"); done
 # Remove installation
 rm -rf ~/.codex/metaswarm
 ```

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -82,6 +82,8 @@ Or re-run the install script — it detects existing installations and updates i
 ## Uninstall
 
 ```bash
+# If CODEX_HOME is set, replace ~/.codex below with "$CODEX_HOME"
+# (or substitute "${CODEX_HOME:-$HOME/.codex}" for both paths).
 # Remove skill symlinks
 for d in ~/.codex/metaswarm/skills/*/; do rm -f ~/.codex/skills/$(basename "$d"); done
 # Remove installation

--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -35,6 +35,22 @@ else
   git clone "$REPO_URL" "$INSTALL_DIR"
 fi
 
+# One-time sweep: remove dangling metaswarm-* symlinks from the legacy
+# ~/.agents/skills location used by 0.10/0.11. Safe to run on machines
+# that never had it (the directory check skips it).
+LEGACY_AGENTS_DIR="$HOME/.agents/skills"
+if [ -d "$LEGACY_AGENTS_DIR" ]; then
+  legacy_removed=0
+  for legacy_link in "$LEGACY_AGENTS_DIR"/metaswarm-*; do
+    [ -L "$legacy_link" ] || continue
+    rm "$legacy_link"
+    legacy_removed=$((legacy_removed + 1))
+  done
+  if [ "$legacy_removed" -gt 0 ]; then
+    echo "  Removed $legacy_removed legacy symlink(s) from $LEGACY_AGENTS_DIR."
+  fi
+fi
+
 # Symlink skills
 echo ""
 echo "  Symlinking skills into $SKILLS_DIR..."
@@ -51,7 +67,8 @@ for skill_dir in "$INSTALL_DIR/skills"/*/; do
     # Update existing symlink
     rm "$target"
   elif [ -d "$target" ]; then
-    echo "  Warning: $target exists as a directory, skipping"
+    echo "  Warning: $target exists as a real directory (not a symlink); skipping."
+    echo "           Remove it manually (rm -rf \"$target\") and re-run if you want the managed copy."
     continue
   fi
 

--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 
 CODEX_ROOT="${CODEX_HOME:-$HOME/.codex}"
 INSTALL_DIR="$CODEX_ROOT/metaswarm"
-SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
+SKILLS_DIR="$CODEX_ROOT/skills"
 REPO_URL="https://github.com/dsifry/metaswarm.git"
 
 echo ""
@@ -41,11 +41,16 @@ fi
 LEGACY_AGENTS_DIR="$HOME/.agents/skills"
 if [ -d "$LEGACY_AGENTS_DIR" ]; then
   legacy_removed=0
+  # nullglob so an unmatched `metaswarm-*` glob expands to nothing instead of
+  # iterating once over the literal pattern (which the symlink test would skip,
+  # but cleaner to never iterate at all).
+  shopt -s nullglob
   for legacy_link in "$LEGACY_AGENTS_DIR"/metaswarm-*; do
     [ -L "$legacy_link" ] || continue
     rm "$legacy_link"
     legacy_removed=$((legacy_removed + 1))
   done
+  shopt -u nullglob
   if [ "$legacy_removed" -gt 0 ]; then
     echo "  Removed $legacy_removed legacy symlink(s) from $LEGACY_AGENTS_DIR."
   fi
@@ -75,7 +80,10 @@ for skill_dir in "$INSTALL_DIR/skills"/*/; do
   if [ -L "$legacy_target" ]; then
     rm "$legacy_target"
   elif [ -e "$legacy_target" ]; then
-    echo "  Warning: legacy path $legacy_target exists and was not removed"
+    echo "  Warning: legacy path $legacy_target exists as a real directory; skipping $skill_name."
+    echo "           Remove it manually (rm -rf \"$legacy_target\") and re-run to avoid"
+    echo "           a duplicate skill entry alongside the new $target symlink."
+    continue
   fi
 
   ln -sf "$skill_dir" "$target"

--- a/.codex/install.sh
+++ b/.codex/install.sh
@@ -9,8 +9,9 @@
 
 set -euo pipefail
 
-INSTALL_DIR="${CODEX_HOME:-$HOME/.codex}/metaswarm"
-SKILLS_DIR="$HOME/.agents/skills"
+CODEX_ROOT="${CODEX_HOME:-$HOME/.codex}"
+INSTALL_DIR="$CODEX_ROOT/metaswarm"
+SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"
 REPO_URL="https://github.com/dsifry/metaswarm.git"
 
 echo ""
@@ -42,8 +43,9 @@ mkdir -p "$SKILLS_DIR"
 linked=0
 for skill_dir in "$INSTALL_DIR/skills"/*/; do
   [ -d "$skill_dir" ] || continue
-  skill_name="metaswarm-$(basename "$skill_dir")"
+  skill_name="$(basename "$skill_dir")"
   target="$SKILLS_DIR/$skill_name"
+  legacy_target="$SKILLS_DIR/metaswarm-$skill_name"
 
   if [ -L "$target" ]; then
     # Update existing symlink
@@ -51,6 +53,12 @@ for skill_dir in "$INSTALL_DIR/skills"/*/; do
   elif [ -d "$target" ]; then
     echo "  Warning: $target exists as a directory, skipping"
     continue
+  fi
+
+  if [ -L "$legacy_target" ]; then
+    rm "$legacy_target"
+  elif [ -e "$legacy_target" ]; then
+    echo "  Warning: legacy path $legacy_target exists and was not removed"
   fi
 
   ln -sf "$skill_dir" "$target"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.12.0
+
+### Added
+- **`/codex-plan-review` slash command**: Iterative Codex-based plan review loop (`commands/codex-plan-review.md`). Codex reviews an implementation plan, Claude reads P0/P1 findings and patches the plan, then Codex re-reviews — until all blocking issues close or max rounds hit. Three tunable profiles (`speed` / `balanced` / `quality`), profile-aware terminal conditions (ACCEPT requires score ≥ floor in `quality`), score-trajectory tracking, hang-watcher, and a `Deferred Gaps (codex)` schema for partial wins.
+- **`spec-gap-review` skill** (`skills/spec-gap-review/`): Codex-runnable skill that audits implementation guides, architecture docs, UX specs, infrastructure plans, memory designs, and roadmaps against the actual repository. Stable 6-dimension rubric, gap IDs (G01, G02…), file:line citations, multi-round delta scoring, and a `validate_line_links.py` helper that verifies every saved citation.
+
+### Changed
+- **Codex skill installation path**: Skills now install to `${CODEX_HOME:-$HOME/.codex}/skills/` (was `~/.agents/skills/metaswarm-*`). Symlink names no longer carry the `metaswarm-` prefix — `$skill-name` invocation matches the SKILL.md `name` field directly.
+- **Both Codex installers** (`.codex/install.sh`, `cli/metaswarm.js`) now sweep dangling `metaswarm-*` symlinks from the legacy `~/.agents/skills/` location on next install, so users upgrading from 0.10/0.11 don't accumulate stale links.
+- **Pre-existing real-directory case**: install scripts now print a clear remediation hint ("Remove it manually and re-run") when a target path exists as a real directory instead of a managed symlink.
+- Counts updated across manifests and root README/GEMINI.md: 13 skills → 14, 15 commands → 16.
+
 ## 0.11.0
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ This triggers the full pipeline: Research → Plan → Design Review Gate → Wo
 | `/brainstorm` | Refine an idea before implementation |
 | `/create-issue` | Create a well-structured GitHub Issue |
 | `/external-tools-health` | Check status of external AI tools (Codex, Gemini) |
+| `/codex-plan-review` | Iterative Codex review of an implementation plan (requires Codex CLI + `npx metaswarm init --codex`) |
 | `/setup` | Interactive guided setup — detects project, configures metaswarm |
 | `/update` | Update metaswarm to latest version |
 | `/status` | Run diagnostic checks on your installation |

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,6 +1,6 @@
 # metaswarm
 
-Multi-agent orchestration framework for software development. 18 specialized agents, 13 skills, quality gates, TDD enforcement.
+Multi-agent orchestration framework for software development. 18 specialized agents, 14 skills, quality gates, TDD enforcement.
 
 ## Getting Started
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,12 @@ Then in Claude Code:
 /setup
 ```
 
+**Note on `/codex-plan-review`**: this command shells out to the Codex CLI for iterative plan review. To use it from Claude Code, you also need:
+1. Codex CLI installed (`npm i -g @openai/codex`) and authenticated.
+2. metaswarm's Codex skills symlinked into `${CODEX_HOME:-$HOME/.codex}/skills/` via `npx metaswarm init --codex` or the Codex install script below.
+
+The command's preflight check will tell you exactly which step is missing.
+
 ## Gemini CLI (Extension)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ metaswarm/
 │   ├── external-tools/       # Cross-model AI delegation (Codex, Gemini CLI)
 │   └── visual-review/        # Playwright-based screenshot review
 ├── commands/                  # Slash commands
-│   ├── *.md                  # Claude Code commands (15 files)
+│   ├── *.md                  # Claude Code commands (16 files)
 │   └── metaswarm/*.toml      # Gemini CLI commands (12 files)
 ├── agents/                    # 18 agent persona definitions
 ├── rubrics/                   # Quality review standards

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # metaswarm
 
-A self-improving multi-agent orchestration framework for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Gemini CLI, and Codex CLI. Coordinate 18 specialized AI agents and 13 orchestration skills through a complete software development lifecycle, from issue to merged PR, with recursive orchestration, parallel review gates, and a git-native knowledge base.
+A self-improving multi-agent orchestration framework for [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Gemini CLI, and Codex CLI. Coordinate 18 specialized AI agents and 14 orchestration skills through a complete software development lifecycle, from issue to merged PR, with recursive orchestration, parallel review gates, and a git-native knowledge base.
 
 ## What Is This?
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -192,6 +192,21 @@ Delegates implementation and review tasks to external AI CLI tools (OpenAI Codex
 
 Configuration: `.metaswarm/external-tools.yaml`. See `templates/external-tools-setup.md` for setup.
 
+### Spec Gap Review
+
+**Path**: `skills/spec-gap-review/SKILL.md`
+
+Codex-runnable critical review of implementation guides, design docs, UX specs, infrastructure plans, and roadmaps against the actual repository — not against the doc's own aspirations.
+
+- **Stable 6-dimension rubric**: scope clarity, behavior completeness, contract specificity, repo alignment, technical feasibility, sequencing/operability — weighted to a `/100` Overall readiness score with `Quality /100` and `Completeness /100` rollups
+- **Gap tracker with stable IDs** (G01, G02…): carry-forward across rounds with `closed | partial | open | new` status
+- **File:line citations** on every finding, validated by `scripts/validate_line_links.py`
+- **Doc-type focus checks**: implementation guide, strategy, memory, UX/API, infrastructure, long-lived agent — each adds 2-4 unscored deepening checks
+- **Critical-Only Mode** for delta rounds focused on P0/P1 blockers
+- **Driven by `/codex-plan-review`**: the slash command runs the iterative review-and-patch loop; the skill runs a single review pass
+
+Requires Codex CLI installed and authenticated. Install Codex skills with `npx metaswarm init --codex` (or the curl one-liner in `.codex/README.md`).
+
 ### Visual Review
 
 **Path**: `skills/visual-review/SKILL.md`

--- a/cli/metaswarm.js
+++ b/cli/metaswarm.js
@@ -56,7 +56,7 @@ function installCodex() {
   console.log('\n  Installing for Codex CLI...\n');
   const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
   const installDir = path.join(codexHome, 'metaswarm');
-  const skillsDir = path.join(process.env.CODEX_HOME || path.join(os.homedir(), '.codex'), 'skills');
+  const skillsDir = path.join(codexHome, 'skills');
 
   if (fs.existsSync(installDir)) {
     console.log(`  Updating existing installation at ${installDir}...`);

--- a/cli/metaswarm.js
+++ b/cli/metaswarm.js
@@ -79,6 +79,28 @@ function installCodex() {
     }
   }
 
+  // One-time sweep: remove dangling metaswarm-* symlinks from the legacy
+  // ~/.agents/skills location used by 0.10/0.11.
+  const legacyAgentsDir = path.join(os.homedir(), '.agents', 'skills');
+  if (fs.existsSync(legacyAgentsDir)) {
+    let legacyRemoved = 0;
+    for (const entry of fs.readdirSync(legacyAgentsDir)) {
+      if (!entry.startsWith('metaswarm-')) continue;
+      const legacyPath = path.join(legacyAgentsDir, entry);
+      try {
+        if (fs.lstatSync(legacyPath).isSymbolicLink()) {
+          fs.unlinkSync(legacyPath);
+          legacyRemoved++;
+        }
+      } catch (e) {
+        if (e.code !== 'ENOENT') warn(`Unexpected error checking ${legacyPath}: ${e.message}`);
+      }
+    }
+    if (legacyRemoved > 0) {
+      info(`Removed ${legacyRemoved} legacy symlink(s) from ${legacyAgentsDir}`);
+    }
+  }
+
   // Symlink skills
   mkdirp(skillsDir);
   const skillsPath = path.join(installDir, 'skills');
@@ -95,7 +117,7 @@ function installCodex() {
         if (fs.lstatSync(linkPath).isSymbolicLink()) {
           fs.unlinkSync(linkPath);
         } else if (fs.existsSync(linkPath)) {
-          warn(`${linkPath} exists as a directory, skipping`);
+          warn(`${linkPath} exists as a real directory (not a symlink); skipping. Remove it manually and re-run to install the managed copy.`);
           continue;
         }
       } catch (e) {

--- a/cli/metaswarm.js
+++ b/cli/metaswarm.js
@@ -54,8 +54,9 @@ function installClaude() {
 
 function installCodex() {
   console.log('\n  Installing for Codex CLI...\n');
-  const installDir = path.join(process.env.CODEX_HOME || path.join(os.homedir(), '.codex'), 'metaswarm');
-  const skillsDir = path.join(os.homedir(), '.agents', 'skills');
+  const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+  const installDir = path.join(codexHome, 'metaswarm');
+  const skillsDir = path.join(process.env.CODEX_HOME || path.join(os.homedir(), '.codex'), 'skills');
 
   if (fs.existsSync(installDir)) {
     console.log(`  Updating existing installation at ${installDir}...`);
@@ -86,8 +87,9 @@ function installCodex() {
     for (const dir of fs.readdirSync(skillsPath)) {
       const srcDir = path.join(skillsPath, dir);
       if (!fs.statSync(srcDir).isDirectory()) continue;
-      const linkName = `metaswarm-${dir}`;
+      const linkName = dir;
       const linkPath = path.join(skillsDir, linkName);
+      const legacyLinkPath = path.join(skillsDir, `metaswarm-${dir}`);
 
       try {
         if (fs.lstatSync(linkPath).isSymbolicLink()) {
@@ -98,6 +100,16 @@ function installCodex() {
         }
       } catch (e) {
         if (e.code !== 'ENOENT') warn(`Unexpected error checking ${linkPath}: ${e.message}`);
+      }
+
+      try {
+        if (fs.lstatSync(legacyLinkPath).isSymbolicLink()) {
+          fs.unlinkSync(legacyLinkPath);
+        } else if (fs.existsSync(legacyLinkPath)) {
+          warn(`Legacy skill path ${legacyLinkPath} exists and was not removed`);
+        }
+      } catch (e) {
+        if (e.code !== 'ENOENT') warn(`Unexpected error checking ${legacyLinkPath}: ${e.message}`);
       }
 
       fs.symlinkSync(srcDir, linkPath);

--- a/cli/metaswarm.js
+++ b/cli/metaswarm.js
@@ -124,15 +124,18 @@ function installCodex() {
         if (e.code !== 'ENOENT') warn(`Unexpected error checking ${linkPath}: ${e.message}`);
       }
 
+      let skipForLegacyDir = false;
       try {
         if (fs.lstatSync(legacyLinkPath).isSymbolicLink()) {
           fs.unlinkSync(legacyLinkPath);
         } else if (fs.existsSync(legacyLinkPath)) {
-          warn(`Legacy skill path ${legacyLinkPath} exists and was not removed`);
+          warn(`Legacy skill path ${legacyLinkPath} exists as a real directory; skipping ${dir}. Remove it manually and re-run to avoid a duplicate skill entry alongside the new ${linkPath} symlink.`);
+          skipForLegacyDir = true;
         }
       } catch (e) {
         if (e.code !== 'ENOENT') warn(`Unexpected error checking ${legacyLinkPath}: ${e.message}`);
       }
+      if (skipForLegacyDir) continue;
 
       fs.symlinkSync(srcDir, linkPath);
       linked++;

--- a/commands/codex-plan-review.md
+++ b/commands/codex-plan-review.md
@@ -1,0 +1,442 @@
+# Codex Plan Gap Review
+
+Run iterative Codex reviews on an implementation plan (or any design doc) using the `spec-gap-review` skill from `${CODEX_HOME:-$HOME/.codex}/skills/spec-gap-review/`. Codex reviews the plan, Claude reads P0/P1 findings and patches the plan, then Codex re-reviews — until all blocking issues are resolved or max rounds reached. During the installer transition, also accept the legacy metaswarm-prefixed path if it already exists.
+
+## Arguments
+
+`$ARGUMENTS` — plan path [flags]
+
+Flags:
+- `--profile <name>` — preset tuning profile: `speed` | `balanced` | `quality`. Default: read `codex.plan_review.profile` from `.metaswarm/external-tools.yaml`, fallback `quality`.
+- `--rounds N` — override max review rounds (ignores profile's rounds setting).
+- `--cwd <path>` — directory Codex runs in. Default: repo root detected via `git rev-parse --show-toplevel` from the plan's directory.
+- `--no-commit` — skip the "stage + suggest commit" step at terminal state.
+- `--critical-from-round <N>` — override profile's Critical-Only Mode start round. Use `never` to disable Critical-Only entirely.
+- `--min-score N` — override profile's score floor (ACCEPT requires Overall ≥ N).
+
+## Profiles
+
+Three tuning presets control the speed-vs-quality tradeoff. The profile expands to a set of internal parameters; individual flags can override any one of them.
+
+| Parameter | `speed` | `balanced` | `quality` (default) |
+|---|---|---|---|
+| `max_rounds` | 2 | 3 | **5** |
+| `iteration_2plus_scope` | `[P0, P1]` | `[P0, P1]` | **`[P0, P1, P2]`** |
+| `critical_from_round` | `2` | `2` | **`never`** (full-review deltas) |
+| `min_overall_score` (ACCEPT floor) | `0` (disabled) | `0` (disabled) | **`90`** |
+| Wall-clock (approx) | ~6 min | ~9 min | ~15 min |
+| Codex tokens (relative) | 1× | 1.5× | 2.5× |
+
+### When to use each
+
+- **`speed`** — cheap sanity check on a plan you think is already solid. Catches egregious issues, doesn't chase quality.
+- **`balanced`** — everyday use. Moves plans from "drafty" to "shippable with known open P2s".
+- **`quality`** — important plans (features touching production invariants, anything with deploy/data risk). Keeps going until P0/P1 are closed AND Overall ≥ 90. This is the default.
+
+### Legacy config compatibility
+
+If `.metaswarm/external-tools.yaml` has legacy keys (`max_rounds`, `critical_from_round`) but no `profile`, those keys win and no profile is applied. To adopt profile-based config, delete the legacy keys and set `plan_review.profile: "<name>"`.
+
+## Preflight
+
+Run these checks before starting the loop. Stop and tell the user exactly what to fix if any fail.
+
+1. **Codex CLI available**: `codex --version` succeeds.
+2. **Codex authenticated**: `codex login status` output contains "Logged in", OR `$OPENAI_API_KEY` / `$CODEX_API_KEY` is set.
+3. **Spec-gap-review skill present**: `${CODEX_HOME:-$HOME/.codex}/skills/spec-gap-review/SKILL.md` exists. During the migration window, also accept `${CODEX_HOME:-$HOME/.codex}/skills/metaswarm-spec-gap-review/SKILL.md`. If neither exists, tell the user: *"Install metaswarm's Codex skills first: `npx metaswarm init --codex` or `curl -sSL https://raw.githubusercontent.com/dsifry/metaswarm/main/.codex/install.sh | bash`."*
+4. **External tools enabled**: `.metaswarm/external-tools.yaml` in the repo has `adapters.codex.enabled: true`. If the file is missing or the flag is false, tell the user: *"Enable codex first: set `adapters.codex.enabled: true` in `.metaswarm/external-tools.yaml`."*
+5. **Plan file exists** and is readable.
+6. **Sibling path**: `<plan-stem>-codexreview.md` in the same directory as the plan. If a stale sibling exists from a prior unrelated run, warn the user and ask whether to overwrite or append.
+7. **Stdin-close probe** (detects non-TTY stdin hang). Run:
+   ```bash
+   # Portable 15 s cap: prefer timeout/gtimeout; otherwise use a pure-bash watchdog.
+   if command -v timeout >/dev/null 2>&1; then
+     timeout 15 codex exec --sandbox read-only "echo ok" < /dev/null
+   elif command -v gtimeout >/dev/null 2>&1; then
+     gtimeout 15 codex exec --sandbox read-only "echo ok" < /dev/null
+   else
+     codex exec --sandbox read-only "echo ok" < /dev/null & probe_pid=$!
+     ( sleep 15 && kill "$probe_pid" 2>/dev/null ) & kill_pid=$!
+     wait "$probe_pid"; probe_exit=$?
+     kill "$kill_pid" 2>/dev/null
+     exit $probe_exit
+   fi
+   ```
+   If it doesn't exit within 15 s, ERROR with phase `preflight-stdin-hang`: *"Codex is hanging before prompt execution. Verify the Step 2 invocation uses `< /dev/null` — see command docs §'Why `< /dev/null`'. This is an environment-level regression; `codex exec` will not be usable from this harness until fixed."* This probe is cheap (~3 s when healthy) and catches the most common failure mode — a Codex CLI version or harness combination that hangs on non-TTY stdin.
+8. **Resolve profile to parameters**. Precedence (highest first):
+   1. CLI flags (`--profile`, `--rounds`, `--critical-from-round`, `--min-score`) — always win
+   2. Legacy individual yaml keys (`codex.plan_review.max_rounds`, `codex.plan_review.critical_from_round`) — used only if `profile` is not set in yaml
+   3. Yaml `codex.plan_review.profile` expanded to defaults
+   4. Built-in default profile: `quality`
+
+   After resolution, the internal state for this run is:
+
+   ```
+   profile            = <resolved name>
+   max_rounds         = <resolved number>
+   iteration_2plus_scope = [P0, P1] or [P0, P1, P2]
+   critical_from_round   = <N> or `never`
+   min_overall_score     = <0 for disabled, or a floor like 90>
+   ```
+
+   **Log the resolved values at start** so the user sees which profile is active:
+
+   ```
+   [codex-plan-review] profile: quality (max_rounds=5, iter_2+_scope=[P0,P1,P2], critical_from=never, min_score=90)
+   ```
+
+## Review Loop
+
+For round = 1 to max_rounds:
+
+### Step 1: Build the prompt
+
+Choose the prompt based on iteration and the resolved `critical_from_round`:
+
+**Round 1** (always uses the baseline prompt, regardless of profile):
+
+```
+Review the implementation plan at <PLAN_PATH> using the spec-gap-review skill.
+Ground the review in the current repository at <CWD>.
+Save the review to <SIBLING_PATH>.
+In the `## Prioritized issues` section, prefix every bullet with its gap ID, e.g. `- **G01** (P1) — <finding>`. This is required for downstream parsing.
+```
+
+**Round N** (N ≥ 2). Two variants depending on whether Critical-Only Mode is active:
+
+**Variant A — Critical-Only delta** (used when `critical_from_round != never` AND current round ≥ `critical_from_round`; applies to `speed` and `balanced` profiles):
+
+```
+Re-review the implementation plan at <PLAN_PATH> using the spec-gap-review skill in Critical-Only Mode.
+Compare against the prior review at <SIBLING_PATH>.
+Update that file in place with a round-aware delta.
+Focus on P0 and P1 issues only. Carry forward stable gap IDs.
+In the `## Prioritized issues` section, prefix every bullet with its gap ID, e.g. `- **G01** (P1) — <finding>`. This is required for downstream parsing.
+```
+
+**Variant B — Full-review delta** (used when `critical_from_round == never`, OR current round < `critical_from_round`; applies to `quality` profile):
+
+```
+Re-review the implementation plan at <PLAN_PATH> using the spec-gap-review skill.
+Compare against the prior review at <SIBLING_PATH>.
+Update that file in place with a round-aware delta review.
+Focus on P0, P1, and P2 issues. Carry forward stable gap IDs.
+In the `## Prioritized issues` section, prefix every bullet with its gap ID, e.g. `- **G01** (P1) — <finding>`. This is required for downstream parsing.
+```
+
+Variant B produces fuller output (P2 findings included), so the patcher in Step 5 has P2 findings to act on. Critical-Only Mode (Variant A) suppresses P2 output to save tokens.
+
+### Step 2: Invoke codex
+
+```bash
+# workspace-write is REQUIRED — the prompt instructs codex to save the sibling review file.
+# Do NOT downgrade to --sandbox read-only; the write will silently fail and the loop errors out.
+#
+# < /dev/null is REQUIRED — see "Why `< /dev/null`" below. Without it, codex hangs
+# at 0% CPU with "Reading additional input from stdin..." and never runs.
+#
+# 3600s (1 hr) is a pathological-case ceiling, not a quality budget. Real hangs are
+# caught earlier by the hang watcher below; this trip only fires if everything else
+# fails. Lower it only if you know the plan is small and want faster ERROR feedback.
+#
+# `timeout(1)` is NOT available on macOS by default (it ships with GNU coreutils only,
+# reachable as `gtimeout` after `brew install coreutils`). Detect and fall back:
+TIMEOUT_CMD=""
+if command -v timeout >/dev/null 2>&1; then TIMEOUT_CMD="timeout 3600";
+elif command -v gtimeout >/dev/null 2>&1; then TIMEOUT_CMD="gtimeout 3600";
+fi
+# If neither exists, the hang-watcher below is the only ceiling. That's acceptable —
+# the watcher catches the real failure modes; the 3600s ceiling is a belt on top of
+# suspenders. Do NOT block the command on requiring coreutils.
+$TIMEOUT_CMD codex exec --sandbox workspace-write --json "<PROMPT>" < /dev/null &
+codex_pid=$!
+```
+
+- **Sandbox must be `workspace-write`, not `read-only`.** The skill needs to write/update the sibling review file. `read-only` would block that. `workspace-write` scopes writes to cwd (the repo root set below), which is what we want — Codex can save the sibling file but can't escape the repo.
+- Run with cwd = `<CWD>` (the repo root, detected from the plan's directory via `git rev-parse --show-toplevel`) so Codex can ground in the repo AND the workspace-write scope covers the plan's directory
+- **Hard ceiling: 3600 s (1 hr)** via `timeout`/`gtimeout` wrapper when available — catches pathological runaways only. `quality` profile nominal wall-clock is ~15 min but can legitimately reach 30+ min on large plans with `xhigh` reasoning, so do **not** lower this to the spec's old "300 s" value (that was wrong for anything beyond a speed sanity check). On systems without `timeout` (macOS default) or `gtimeout` (macOS with `brew install coreutils`), the hang-watcher below is the only ceiling — the command still works, just without the 1 hr belt-and-suspenders.
+- Pass only `HOME`, `PATH`, `OPENAI_API_KEY`, `CODEX_API_KEY` in env (minimal)
+- Capture stdout for error/status only; do NOT parse stdout for the scorecard
+
+#### Why `< /dev/null`
+
+Codex 0.121.0+ treats **any non-TTY stdin** as "someone might pipe me input, let me wait for EOF before processing." In Claude Code's Bash tool (and any CI or agent harness), stdin is inherited from a long-running parent process and never closes. Result: the prompt argv is parsed but never executed — the process sits at 0 % CPU, 0 ESTABLISHED TCP connections, sibling file never created. The log stops at `Reading additional input from stdin...`.
+
+Redirecting stdin from `/dev/null` delivers EOF immediately; codex skips the "stdin append" path and uses only the argv prompt. Works in TTY, non-TTY, CI, and backgrounded contexts identically.
+
+*Do not* remove the `/dev/null` redirect on the theory that "the prompt is passed as argv, why would codex read stdin?" — codex reads stdin regardless, to support the `"<prompt> + <stdin>-appended-block"` invocation pattern documented in `codex exec --help`.
+
+#### Hang-watcher (required)
+
+The 3600 s `timeout` catches catastrophic hangs but wastes an hour of wall-clock. A live codex run fluctuates between three observable signals — **reasoning** (≥1 % CPU), **tool calls** (≥1 ESTABLISHED TCP), **file I/O** (sibling file or log size changes). A stuck run shows 0 on all three. Watch for that signature:
+
+```bash
+# Poll every 60 s while codex is running. If ALL THREE signals are 0 for 5
+# consecutive samples (5 min), kill codex — it's hung, not working.
+hang_count=0
+last_log_size=0
+last_sibling_size=0
+while kill -0 "$codex_pid" 2>/dev/null; do
+  sleep 60
+  cpu=$(ps -p "$codex_pid" -o pcpu= 2>/dev/null | tr -d ' ')
+  net=$(lsof -p "$codex_pid" -iTCP -sTCP:ESTABLISHED -n 2>/dev/null | wc -l | tr -d ' ')
+  log_size=$(wc -c < "$CODEX_LOG" 2>/dev/null || echo 0)
+  sibling_size=$(wc -c < "$SIBLING_PATH" 2>/dev/null || echo 0)
+  if [[ "${cpu%%.*}" == "0" ]] \
+     && [[ "$net" == "0" ]] \
+     && [[ "$log_size" == "$last_log_size" ]] \
+     && [[ "$sibling_size" == "$last_sibling_size" ]]; then
+    hang_count=$((hang_count + 1))
+    if [[ "$hang_count" -ge 5 ]]; then
+      kill "$codex_pid" 2>/dev/null
+      break  # classify as codex-hang below
+    fi
+  else
+    hang_count=0
+  fi
+  last_log_size=$log_size
+  last_sibling_size=$sibling_size
+done
+wait "$codex_pid"
+codex_exit=$?
+```
+
+Why all four signals in the conjunction (not just CPU)? A codex run streaming reasoning tokens can appear to idle CPU while the log grows; a run doing a long file write can have 0 CPU and 0 network. Requiring all four to be flat ≥5 min is the narrowest filter that still catches the real "stdin-wait" signature observed in practice.
+
+**If the watcher kills codex**: classify as `codex-hang` (distinct from `codex-timeout` which means the 3600 s ceiling tripped). Retry once with the same prompt. If it hangs again, ERROR with phase `codex-hang`: *"Codex stalled at 0 % CPU / 0 network / 0 file I/O for 5 min. Verify `< /dev/null` is in the invocation and that codex 0.121.0+ is installed. See command docs §'Why `< /dev/null`'."*
+
+If codex exits non-zero:
+- Exit code 124 (from `timeout`): classify as `codex-timeout`. Retry once. Second failure → ERROR phase `codex-timeout`.
+- Exit code from hang-watcher `kill`: classify as `codex-hang` (above).
+- Any other non-zero: first failure retry once with the same prompt; second failure stop the loop, report stderr + exit code, suggest `codex login status` to the user.
+
+### Step 3: Read the sibling file
+
+After a successful codex invocation, read `<SIBLING_PATH>`.
+
+Expected structure (from spec-gap-review skill Output Shape):
+
+| Section | What it contains |
+|---|---|
+| `## Round status` | round number, delta-vs-baseline flag |
+| `## Executive summary` | 2–3 sentences |
+| `## Rollups` | Overall /100, Quality /100, Completeness /100 + deltas |
+| `## Core scorecard` | 6 rubric dimensions × (score, weight, points, delta) |
+| `## Gap tracker` | stable IDs (G01, G02…) × status (closed, partial, open, new) |
+| `## Detailed findings` | grouped by rubric area with file:line references |
+| `## Prioritized issues` | P0, P1, P2, P3 sections |
+| `## Path to 100` | exact changes needed |
+| `## Recommended next actions` | top 5 highest-leverage fixes |
+
+If the file is not usable, classify precisely — the fix for each sub-case differs:
+
+- **File missing** (sibling was never created): Codex was blocked from writing or never started. Most common causes, in order of observed frequency:
+  1. **Stdin hang** — `< /dev/null` missing from the Step 2 invocation. Check the codex log for `Reading additional input from stdin...`; if present, that's the cause. → ERROR, phase: `codex-stdin-hang`. Point the user at §'Why `< /dev/null`'.
+  2. **Sandbox too restrictive** — `--sandbox read-only` instead of `workspace-write`. → ERROR, phase: `codex-write-blocked`. Tell the user to verify the sandbox flag.
+  3. **Filesystem** — gitignored path, full disk, permissions. → ERROR, phase: `codex-write-blocked`.
+  4. **Hang watcher fired** — see `codex-hang` classification in Step 2.
+- **File present but malformed** (missing one or more required sections, especially `## Prioritized issues`): Codex produced non-spec output. Likely a Codex CLI regression, a skill-prompt mismatch, or an OOM truncation. → ERROR, phase: `file-parse`. Surface the first and last 20 lines of the sibling file so the user can diagnose.
+- **File present but `Prioritized issues` bullets lack gap ID prefixes**: fall back to scanning `## Detailed findings` for GID↔severity mapping before giving up. If that also fails → ERROR, phase: `file-parse`.
+
+### Step 4: Parse the terminal condition
+
+**Capture score trajectory.** Before evaluating terminal conditions, record this round's Overall / Quality / Completeness scores from the `## Rollups` section. Append to a running list for use in Wrap-up terminal outputs.
+
+**Count open blockers.** From `## Prioritized issues`, map each bullet's gap ID to its status in `## Gap tracker`:
+
+- Count P0 entries whose gap-tracker status is `open`, `partial`, or `new` (ignore `closed`).
+- Count P1 entries whose gap-tracker status is `open`, `partial`, or `new`.
+
+If `## Prioritized issues` bullets lack GID prefixes despite the prompt instruction, fall back to `## Detailed findings` which always cites the GID next to the severity.
+
+**Evaluate terminal conditions in this order:**
+
+**ACCEPT** — ALL of the following:
+- Open P0 count == 0
+- Open P1 count == 0
+- `min_overall_score == 0` (disabled) OR the current Overall score ≥ `min_overall_score`
+
+The score-floor clause catches a subtle quality gap: a plan can have "no P0/P1 blockers" yet still sit at Overall 82 because of stable-by-design P2s. In `quality` profile, the 90 floor forces Codex to either close enough P2s to lift the score OR confirm that the remaining P2s are genuinely "deliberate design choices" (skill closes them as such, which restores the score). Terminate successfully.
+
+**STALLED** — **BOTH** of the following are true:
+- (a) The set of open gap IDs is identical to the prior round's (same IDs, same count)
+- (b) The Overall readiness score is unchanged OR regressed vs. the prior round
+
+The score-regression clause is critical: if gap IDs repeat but the Overall score improved by any margin, the loop is **narrowing** (Codex is finding new nuances within the same gaps), not stalling. Only declare STALLED when patches stop moving the scorecard. Terminate without ACCEPT.
+
+**MAX_ROUNDS** — round == max_rounds and neither ACCEPT nor STALLED applies. Terminate without ACCEPT.
+
+Otherwise continue to Step 5.
+
+### Step 5: Patch the plan
+
+**Scope of fixes depends on iteration AND the resolved profile's `iteration_2plus_scope`:**
+
+| Iteration | Scope (all profiles) |
+|---|---|
+| **Iteration 1** (first Codex pass) | Every open finding: P0, P1, P2, P3 (not `closed`) |
+| **Iteration 2+** | Findings whose severity is in `iteration_2plus_scope` (set by profile): `speed`/`balanced` → `[P0, P1]`; `quality` → `[P0, P1, P2]` |
+
+If the profile includes P2 in iteration 2+ (quality), Codex is run without Critical-Only Mode so its output carries P2 findings to act on. If the profile excludes P2 (speed, balanced), Critical-Only Mode is active and P2 is only addressed when the skill promotes it to blocking per its own Critical-Only rule.
+
+Rationale: the first review has the most signal. Most P2/P3 findings are cheap to fix alongside P0/P1 while the plan is open. In subsequent rounds, P2/P3 "noise" distracts from the blockers and risks churning on stable-by-design choices. The spec-gap-review skill's rule — *"Do not keep re-penalizing a deliberate design choice… if the choice is internally consistent, repo-aligned, and operationally workable, treat it as a tradeoff, not a standing gap"* — further supports ignoring stable P2/P3 after iteration 1.
+
+**Drift exception for iteration 2+.** You MAY touch P2/P3 content in iteration 2+ when it's necessary to remove drift introduced by a P0/P1 fix — e.g., if a P1 invariant rewrite leaves contradictory prose in a section flagged as P2 in round 1, update the P2-flagged content to resolve the contradiction. You may NOT touch P2/P3 content in iteration 2+ for independent improvement. The test is: "Does leaving this P2/P3 content intact make my P0/P1 fix incomplete or self-contradictory?" If yes, touch it. If no, leave it.
+
+For each finding in scope:
+
+1. Read the referenced plan section (use the file:line citations)
+2. **Verify the citation** — for each file:line reference in the finding, read the cited location in the current repo to confirm it matches what Codex described. Codex's file:line citations can be stale (after a recent edit) or misinterpreted. If a citation is wrong, the finding may still be valid but the fix target may need adjustment. Do not apply fixes based on citations you have not verified.
+3. Apply the fix described in the finding OR in the `Path to 100` section
+4. Verify intra-doc consistency — if the fix touches a type/schema/command, check every other reference to it in the plan
+5. Note the change: one line per finding, format `- <GID> <severity>: <what changed>`
+
+After patching, loop to Step 1 for the next iteration.
+
+## Wrap-up
+
+Report one of these outcomes:
+
+### ACCEPTED (round N, score X/100)
+
+```
+CODEX PLAN REVIEW: ACCEPTED
+Profile: <profile-name>
+Plan: <PLAN_PATH>
+Rounds run: N
+Final score: Overall X/100, Quality Y/100, Completeness Z/100
+Score trajectory (Overall): <R1-score> → <R2-score> → ... → <final>
+Score floor (min_overall_score): <value or "disabled">
+Review file: <SIBLING_PATH>
+Fixes applied across rounds: <count>
+```
+
+Unless `--no-commit`:
+1. `git -C <CWD> add <PLAN_PATH> <SIBLING_PATH>`
+2. Print `git -C <CWD> diff --cached --stat`
+3. Suggest commit message:
+   `docs(plan): <plan-stem> — codex gap review PASS (N rounds, score X/100)`
+4. **Do NOT auto-commit**. User commits when satisfied.
+
+### MAX_ROUNDS (round cap hit)
+
+```
+CODEX PLAN REVIEW: MAX_ROUNDS
+Profile: <profile-name>
+Plan: <PLAN_PATH>
+Rounds run: N (cap)
+Open blocking issues: <P0 count> P0, <P1 count> P1
+Final Overall score: <X>/100 (floor: <min_overall_score or "disabled">)
+Score trajectory (Overall): <R1-score> → <R2-score> → ... → <final>
+Last-round Overall delta: <+N / -N / 0>
+Review file: <SIBLING_PATH>
+```
+
+List the remaining P0 and P1 findings. Offer three options:
+1. **Accept and defer** — append a `## Deferred Gaps (codex)` section to the plan (see schema below) enumerating the remaining issues, treating them as "to be covered in implementation". Commit as `ACCEPTED (deferred)`.
+2. **Revise manually and re-run** — user edits the plan, then runs `/codex-plan-review <plan-path>` again (command iteration counter resets; skill absolute round counter continues).
+3. **Abort** — no changes committed. Sibling file stays for reference.
+
+**Recommendation hint**: if the last-round Overall delta is ≥ +5, mark option (2) as recommended. The loop is converging; one more re-run is likely to reach ACCEPT. Format:
+
+```
+2. **Revise manually and re-run** ← recommended (score trending up: +<delta> last round)
+```
+
+If the last-round delta is ≤ 0 or < +5, present the three options neutrally without marking any as recommended.
+
+Ask the user which to choose. Do not pick for them.
+
+**Deferred Gaps (codex) schema.** When a user chooses option (1) at MAX_ROUNDS or STALLED, append this exact structure at the end of the plan (after all existing content, before any trailing whitespace). Future invocations of `/codex-plan-review` detect these IDs and either close them (if the plan evolved) or carry them forward with stable lineage.
+
+```markdown
+## Deferred Gaps (codex)
+
+Preserved from Codex plan review on <YYYY-MM-DD>. These findings are deferred to implementation and not treated as blockers.
+
+- **<GID>** (<severity>) — <one-line summary from the sibling file>. Review: `<relative-sibling-path>`.
+- **<GID>** (<severity>) — <one-line summary from the sibling file>. Review: `<relative-sibling-path>`.
+```
+
+Each row preserves the exact gap ID from the final sibling file. `<relative-sibling-path>` is relative to the plan file (usually `./<plan-stem>-codexreview.md`).
+
+### STALLED
+
+```
+CODEX PLAN REVIEW: STALLED
+Profile: <profile-name>
+Plan: <PLAN_PATH>
+Rounds run: N
+Reason: Open gap IDs unchanged AND Overall score unchanged-or-regressed between rounds (N-1) and N — patches are not moving the needle.
+Score trajectory (Overall): <R1-score> → <R2-score> → ... → <final>
+Review file: <SIBLING_PATH>
+```
+
+This usually means Claude's fix pass isn't addressing the real issue Codex is flagging. Ask the user to review the findings manually. Offer the same three options as MAX_ROUNDS (including the Deferred Gaps schema if they choose option 1). Do NOT suggest option 2 as recommended in STALLED — by definition the loop is not converging, so re-running without plan revision is unlikely to help.
+
+### ERROR
+
+```
+CODEX PLAN REVIEW: ERROR
+Phase: <preflight | codex-invocation | file-parse>
+Detail: <message>
+```
+
+For preflight errors, tell the user the exact fix. For codex-invocation errors, surface the stderr tail. For file-parse errors, print the unparseable section of the sibling file.
+
+## Division of Labor (Command vs Skill)
+
+This command and the `spec-gap-review` Codex skill both have "round" and "loop" concepts. They are **deliberately different**, with a clean ownership split. Claude should never try to override the skill's internal logic — read its output, trust it, and act.
+
+| Concern | Owned by | Notes |
+|---|---|---|
+| **Rubric & scoring** (6 dims × 0–5, /100 rollups) | Skill | Command never re-scores or overrides |
+| **Gap IDs** (G01, G02…) | Skill | Command reads them, never assigns |
+| **Round number in the sibling file** | Skill | Counts absolute review rounds on this plan's *file lineage* |
+| **Loop iteration counter** (1 of max_rounds) | **Command** | Counts Codex invocations in *this command invocation* |
+| **In-place file update** | Skill | Triggered by the command's prompt saying "save" or "update in place" |
+| **Critical-Only Mode** | Skill | Activated by the command's prompt phrasing on iteration 2+ |
+| **"Don't re-penalize deliberate choices" rule** | Skill | Command trusts it; doesn't second-guess stable P2/P3 |
+| **Terminal condition** (0 P0 + 0 P1) | **Command** | Skill always produces findings; command decides when to stop calling it |
+| **Patching the plan** | **Command** (via Claude) | Skill is read-only on the plan itself |
+| **Commit staging** | **Command** | Only at ACCEPT terminal state |
+
+### Round number disambiguation
+
+The two counters are independent by design:
+
+- **Skill's `Round status`**: `Round N` in the saved file counts how many times this plan's sibling file has been reviewed across its entire lifetime (every `/codex-plan-review` invocation ever).
+- **Command's iteration counter**: `N of max_rounds` in command output counts Codex invocations within *this* command invocation only.
+
+If a user runs `/codex-plan-review plan.md` once and hits MAX_ROUNDS, then runs it again days later after revisions, the skill might emit `Round 4` on the first Codex call while the command reports `iteration 1 of 3`. **Both are correct.** On iteration 1, **always** log both unconditionally (not only when they diverge — the unconditional log aids debugging and costs nothing):
+
+```
+[codex-plan-review] iteration 1 of 3
+[codex-plan-review] skill reports this is round N of plan review lineage
+```
+
+**Iteration counter reset rules:**
+
+- The iteration counter **resets to 1** on ERROR terminal (no usable sibling file was produced, so there's nothing to resume from).
+- The iteration counter **continues incrementing** on ACCEPT, MAX_ROUNDS, and STALLED terminals — but since these are terminal, "continues" only applies if the user manually re-runs with the same sibling file in place. In that case the command starts fresh at `iteration 1 of 3` again; the skill's absolute round counter keeps advancing because the sibling file persists.
+
+### How the prompts avoid competition
+
+| Iteration | Prompt verb | Triggers skill behavior |
+|---|---|---|
+| 1 (no sibling exists) | "Save the review to …" | Skill treats as `Round 1 - Baseline` |
+| 1 (sibling exists from prior invocation) | "Save the review to …" | Skill detects existing file, updates in place with next round number |
+| 2+ (within same invocation) | "Update that file in place… Critical-Only Mode" | Skill updates delta, switches to critical-only output |
+
+The command never tells the skill what round number to use. The skill never tells the command when to stop calling. Clean separation.
+
+### If the sibling file exists on entry
+
+Preflight asks whether to overwrite (start fresh) or continue (skill will pick up from last saved round). Default: continue. To force a fresh baseline, delete the sibling manually before running, or answer "overwrite" at the preflight prompt.
+
+## Notes
+
+- **Doc-type agnostic.** `spec-gap-review` handles PRDs, implementation guides, strategy docs, infrastructure plans, memory designs. This command doesn't care what kind of doc you pass.
+- **No mid-loop commits.** Intermediate iterations are not committed. The sibling file preserves round-to-round history inside itself via gap ID status evolution (`new` → `open` → `partial` → `closed`). At ACCEPT, one commit contains the final plan + final review file.
+- **Not a substitute for `plan-review-gate`.** This runs AFTER the metaswarm plan-review-gate passes — Codex is a cross-model second opinion, not a replacement for the 3 adversarial Claude reviewers.
+- **Related**: `.metaswarm/external-tools.yaml` also controls code-level Codex review in orchestrated execution (Codex as implementer or reviewer in work units). That's a separate pipeline; this command only reviews planning documents.

--- a/commands/codex-plan-review.md
+++ b/commands/codex-plan-review.md
@@ -148,7 +148,14 @@ fi
 # If neither exists, the hang-watcher below is the only ceiling. That's acceptable —
 # the watcher catches the real failure modes; the 3600s ceiling is a belt on top of
 # suspenders. Do NOT block the command on requiring coreutils.
-$TIMEOUT_CMD codex exec --sandbox workspace-write --json "<PROMPT>" < /dev/null &
+#
+# CODEX_LOG captures combined stdout/stderr so the hang-watcher (below) can use
+# log size as one of its activity signals. Without it, $CODEX_LOG would be unset,
+# `wc -c < "$CODEX_LOG"` always emits 0, and the watcher loses one of its four
+# signals — risking false-positive `codex-hang` on reasoning-heavy rounds with
+# no tool calls and no sibling-file writes yet.
+CODEX_LOG=$(mktemp)
+$TIMEOUT_CMD codex exec --sandbox workspace-write --json "<PROMPT>" < /dev/null >"$CODEX_LOG" 2>&1 &
 codex_pid=$!
 ```
 

--- a/commands/codex-plan-review.md
+++ b/commands/codex-plan-review.md
@@ -46,7 +46,7 @@ Run these checks before starting the loop. Stop and tell the user exactly what t
 3. **Spec-gap-review skill present**: `${CODEX_HOME:-$HOME/.codex}/skills/spec-gap-review/SKILL.md` exists. During the migration window, also accept `${CODEX_HOME:-$HOME/.codex}/skills/metaswarm-spec-gap-review/SKILL.md`. If neither exists, tell the user: *"Install metaswarm's Codex skills first: `npx metaswarm init --codex` or `curl -sSL https://raw.githubusercontent.com/dsifry/metaswarm/main/.codex/install.sh | bash`."*
 4. **External tools enabled**: `.metaswarm/external-tools.yaml` in the repo has `adapters.codex.enabled: true`. If the file is missing or the flag is false, tell the user: *"Enable codex first: set `adapters.codex.enabled: true` in `.metaswarm/external-tools.yaml`."*
 5. **Plan file exists** and is readable.
-6. **Sibling path**: `<plan-stem>-codexreview.md` in the same directory as the plan. If a stale sibling exists from a prior unrelated run, warn the user and ask whether to overwrite or append.
+6. **Sibling path**: `<plan-stem>-codexreview.md` in the same directory as the plan. If a stale sibling exists from a prior unrelated run, warn the user and ask whether to overwrite (start fresh) or continue (skill picks up from the last saved round). Default: continue. See "If the sibling file exists on entry" below for details.
 7. **Stdin-close probe** (detects non-TTY stdin hang). Run:
    ```bash
    # Portable 15 s cap: prefer timeout/gtimeout; otherwise use a pure-bash watchdog.
@@ -95,7 +95,7 @@ Choose the prompt based on iteration and the resolved `critical_from_round`:
 
 **Round 1** (always uses the baseline prompt, regardless of profile):
 
-```
+```text
 Review the implementation plan at <PLAN_PATH> using the spec-gap-review skill.
 Ground the review in the current repository at <CWD>.
 Save the review to <SIBLING_PATH>.
@@ -106,7 +106,7 @@ In the `## Prioritized issues` section, prefix every bullet with its gap ID, e.g
 
 **Variant A — Critical-Only delta** (used when `critical_from_round != never` AND current round ≥ `critical_from_round`; applies to `speed` and `balanced` profiles):
 
-```
+```text
 Re-review the implementation plan at <PLAN_PATH> using the spec-gap-review skill in Critical-Only Mode.
 Compare against the prior review at <SIBLING_PATH>.
 Update that file in place with a round-aware delta.
@@ -116,7 +116,7 @@ In the `## Prioritized issues` section, prefix every bullet with its gap ID, e.g
 
 **Variant B — Full-review delta** (used when `critical_from_round == never`, OR current round < `critical_from_round`; applies to `quality` profile):
 
-```
+```text
 Re-review the implementation plan at <PLAN_PATH> using the spec-gap-review skill.
 Compare against the prior review at <SIBLING_PATH>.
 Update that file in place with a round-aware delta review.
@@ -306,7 +306,7 @@ Report one of these outcomes:
 
 ### ACCEPTED (round N, score X/100)
 
-```
+```text
 CODEX PLAN REVIEW: ACCEPTED
 Profile: <profile-name>
 Plan: <PLAN_PATH>
@@ -327,7 +327,7 @@ Unless `--no-commit`:
 
 ### MAX_ROUNDS (round cap hit)
 
-```
+```text
 CODEX PLAN REVIEW: MAX_ROUNDS
 Profile: <profile-name>
 Plan: <PLAN_PATH>
@@ -346,7 +346,7 @@ List the remaining P0 and P1 findings. Offer three options:
 
 **Recommendation hint**: if the last-round Overall delta is ≥ +5, mark option (2) as recommended. The loop is converging; one more re-run is likely to reach ACCEPT. Format:
 
-```
+```markdown
 2. **Revise manually and re-run** ← recommended (score trending up: +<delta> last round)
 ```
 
@@ -369,7 +369,7 @@ Each row preserves the exact gap ID from the final sibling file. `<relative-sibl
 
 ### STALLED
 
-```
+```text
 CODEX PLAN REVIEW: STALLED
 Profile: <profile-name>
 Plan: <PLAN_PATH>
@@ -383,7 +383,7 @@ This usually means Claude's fix pass isn't addressing the real issue Codex is fl
 
 ### ERROR
 
-```
+```text
 CODEX PLAN REVIEW: ERROR
 Phase: <preflight | codex-invocation | file-parse>
 Detail: <message>
@@ -417,7 +417,7 @@ The two counters are independent by design:
 
 If a user runs `/codex-plan-review plan.md` once and hits MAX_ROUNDS, then runs it again days later after revisions, the skill might emit `Round 4` on the first Codex call while the command reports `iteration 1 of 3`. **Both are correct.** On iteration 1, **always** log both unconditionally (not only when they diverge — the unconditional log aids debugging and costs nothing):
 
-```
+```text
 [codex-plan-review] iteration 1 of 3
 [codex-plan-review] skill reports this is round N of plan review lineage
 ```

--- a/commands/codex-plan-review.md
+++ b/commands/codex-plan-review.md
@@ -183,6 +183,7 @@ The 3600 s `timeout` catches catastrophic hangs but wastes an hour of wall-clock
 hang_count=0
 last_log_size=0
 last_sibling_size=0
+hang_killed=false
 while kill -0 "$codex_pid" 2>/dev/null; do
   sleep 60
   cpu=$(ps -p "$codex_pid" -o pcpu= 2>/dev/null | tr -d ' ')
@@ -195,8 +196,9 @@ while kill -0 "$codex_pid" 2>/dev/null; do
      && [[ "$sibling_size" == "$last_sibling_size" ]]; then
     hang_count=$((hang_count + 1))
     if [[ "$hang_count" -ge 5 ]]; then
+      hang_killed=true
       kill "$codex_pid" 2>/dev/null
-      break  # classify as codex-hang below
+      break  # classify as codex-hang below (gated on $hang_killed)
     fi
   else
     hang_count=0
@@ -213,8 +215,8 @@ Why all four signals in the conjunction (not just CPU)? A codex run streaming re
 **If the watcher kills codex**: classify as `codex-hang` (distinct from `codex-timeout` which means the 3600 s ceiling tripped). Retry once with the same prompt. If it hangs again, ERROR with phase `codex-hang`: *"Codex stalled at 0 % CPU / 0 network / 0 file I/O for 5 min. Verify `< /dev/null` is in the invocation and that codex 0.121.0+ is installed. See command docs §'Why `< /dev/null`'."*
 
 If codex exits non-zero:
+- `$hang_killed == true`: classify as `codex-hang` (above). Check this **first**, before consulting `$codex_exit`, because the SIGTERM exit code (typically 143) is otherwise indistinguishable from any other non-zero exit.
 - Exit code 124 (from `timeout`): classify as `codex-timeout`. Retry once. Second failure → ERROR phase `codex-timeout`.
-- Exit code from hang-watcher `kill`: classify as `codex-hang` (above).
 - Any other non-zero: first failure retry once with the same prompt; second failure stop the loop, report stderr + exit code, suggest `codex login status` to the user.
 
 ### Step 3: Read the sibling file

--- a/commands/codex-plan-review.md
+++ b/commands/codex-plan-review.md
@@ -1,6 +1,6 @@
 # Codex Plan Gap Review
 
-Run iterative Codex reviews on an implementation plan (or any design doc) using the `spec-gap-review` skill from `${CODEX_HOME:-$HOME/.codex}/skills/spec-gap-review/`. Codex reviews the plan, Claude reads P0/P1 findings and patches the plan, then Codex re-reviews — until all blocking issues are resolved or max rounds reached. During the installer transition, also accept the legacy metaswarm-prefixed path if it already exists.
+Run iterative Codex reviews on an implementation plan (or any design doc) using the `$spec-gap-review` skill (installed at `${CODEX_HOME:-$HOME/.codex}/skills/spec-gap-review/`). Codex reviews the plan, Claude reads P0/P1 findings and patches the plan, then Codex re-reviews — until all blocking issues are resolved or max rounds reached. During the installer transition, also accept the legacy metaswarm-prefixed path if it already exists.
 
 ## Arguments
 
@@ -96,7 +96,7 @@ Choose the prompt based on iteration and the resolved `critical_from_round`:
 **Round 1** (always uses the baseline prompt, regardless of profile):
 
 ```text
-Review the implementation plan at <PLAN_PATH> using the spec-gap-review skill.
+Review the implementation plan at <PLAN_PATH> using the `$spec-gap-review` skill.
 Ground the review in the current repository at <CWD>.
 Save the review to <SIBLING_PATH>.
 In the `## Prioritized issues` section, prefix every bullet with its gap ID, e.g. `- **G01** (P1) — <finding>`. This is required for downstream parsing.
@@ -107,7 +107,7 @@ In the `## Prioritized issues` section, prefix every bullet with its gap ID, e.g
 **Variant A — Critical-Only delta** (used when `critical_from_round != never` AND current round ≥ `critical_from_round`; applies to `speed` and `balanced` profiles):
 
 ```text
-Re-review the implementation plan at <PLAN_PATH> using the spec-gap-review skill in Critical-Only Mode.
+Re-review the implementation plan at <PLAN_PATH> using the `$spec-gap-review` skill in Critical-Only Mode.
 Compare against the prior review at <SIBLING_PATH>.
 Update that file in place with a round-aware delta.
 Focus on P0 and P1 issues only. Carry forward stable gap IDs.
@@ -117,7 +117,7 @@ In the `## Prioritized issues` section, prefix every bullet with its gap ID, e.g
 **Variant B — Full-review delta** (used when `critical_from_round == never`, OR current round < `critical_from_round`; applies to `quality` profile):
 
 ```text
-Re-review the implementation plan at <PLAN_PATH> using the spec-gap-review skill.
+Re-review the implementation plan at <PLAN_PATH> using the `$spec-gap-review` skill.
 Compare against the prior review at <SIBLING_PATH>.
 Update that file in place with a round-aware delta review.
 Focus on P0, P1, and P2 issues. Carry forward stable gap IDs.
@@ -221,7 +221,7 @@ If codex exits non-zero:
 
 After a successful codex invocation, read `<SIBLING_PATH>`.
 
-Expected structure (from spec-gap-review skill Output Shape):
+Expected structure (from `$spec-gap-review` skill Output Shape):
 
 | Section | What it contains |
 |---|---|
@@ -254,7 +254,7 @@ If the file is not usable, classify precisely — the fix for each sub-case diff
 - Count P0 entries whose gap-tracker status is `open`, `partial`, or `new` (ignore `closed`).
 - Count P1 entries whose gap-tracker status is `open`, `partial`, or `new`.
 
-If `## Prioritized issues` bullets lack GID prefixes despite the prompt instruction, fall back to `## Detailed findings` which always cites the GID next to the severity.
+If `## Prioritized issues` bullets lack GID prefixes despite the prompt instruction, attempt a deterministic fallback only if the sibling file's `## Detailed findings` section explicitly includes GIDs alongside severities. If no deterministic GID-to-severity mapping is recoverable from either section, classify as `file-parse` (Step 3) — do not guess.
 
 **Evaluate terminal conditions in this order:**
 
@@ -286,7 +286,7 @@ Otherwise continue to Step 5.
 
 If the profile includes P2 in iteration 2+ (quality), Codex is run without Critical-Only Mode so its output carries P2 findings to act on. If the profile excludes P2 (speed, balanced), Critical-Only Mode is active and P2 is only addressed when the skill promotes it to blocking per its own Critical-Only rule.
 
-Rationale: the first review has the most signal. Most P2/P3 findings are cheap to fix alongside P0/P1 while the plan is open. In subsequent rounds, P2/P3 "noise" distracts from the blockers and risks churning on stable-by-design choices. The spec-gap-review skill's rule — *"Do not keep re-penalizing a deliberate design choice… if the choice is internally consistent, repo-aligned, and operationally workable, treat it as a tradeoff, not a standing gap"* — further supports ignoring stable P2/P3 after iteration 1.
+Rationale: the first review has the most signal. Most P2/P3 findings are cheap to fix alongside P0/P1 while the plan is open. In subsequent rounds, P2/P3 "noise" distracts from the blockers and risks churning on stable-by-design choices. The `$spec-gap-review` skill's rule — *"Do not keep re-penalizing a deliberate design choice… if the choice is internally consistent, repo-aligned, and operationally workable, treat it as a tradeoff, not a standing gap"* — further supports ignoring stable P2/P3 after iteration 1.
 
 **Drift exception for iteration 2+.** You MAY touch P2/P3 content in iteration 2+ when it's necessary to remove drift introduced by a P0/P1 fix — e.g., if a P1 invariant rewrite leaves contradictory prose in a section flagged as P2 in round 1, update the P2-flagged content to resolve the contradiction. You may NOT touch P2/P3 content in iteration 2+ for independent improvement. The test is: "Does leaving this P2/P3 content intact make my P0/P1 fix incomplete or self-contradictory?" If yes, touch it. If no, leave it.
 
@@ -393,7 +393,7 @@ For preflight errors, tell the user the exact fix. For codex-invocation errors, 
 
 ## Division of Labor (Command vs Skill)
 
-This command and the `spec-gap-review` Codex skill both have "round" and "loop" concepts. They are **deliberately different**, with a clean ownership split. Claude should never try to override the skill's internal logic — read its output, trust it, and act.
+This command and the `$spec-gap-review` Codex skill both have "round" and "loop" concepts. They are **deliberately different**, with a clean ownership split. Claude should never try to override the skill's internal logic — read its output, trust it, and act.
 
 | Concern | Owned by | Notes |
 |---|---|---|
@@ -443,7 +443,7 @@ Preflight asks whether to overwrite (start fresh) or continue (skill will pick u
 
 ## Notes
 
-- **Doc-type agnostic.** `spec-gap-review` handles PRDs, implementation guides, strategy docs, infrastructure plans, memory designs. This command doesn't care what kind of doc you pass.
+- **Doc-type agnostic.** `$spec-gap-review` handles PRDs, implementation guides, strategy docs, infrastructure plans, memory designs. This command doesn't care what kind of doc you pass.
 - **No mid-loop commits.** Intermediate iterations are not committed. The sibling file preserves round-to-round history inside itself via gap ID status evolution (`new` → `open` → `partial` → `closed`). At ACCEPT, one commit contains the final plan + final review file.
-- **Not a substitute for `plan-review-gate`.** This runs AFTER the metaswarm plan-review-gate passes — Codex is a cross-model second opinion, not a replacement for the 3 adversarial Claude reviewers.
+- **Not a substitute for `$plan-review-gate`.** This runs AFTER the metaswarm `$plan-review-gate` passes — Codex is a cross-model second opinion, not a replacement for the 3 adversarial Claude reviewers.
 - **Related**: `.metaswarm/external-tools.yaml` also controls code-level Codex review in orchestrated execution (Codex as implementer or reviewer in work units). That's a separate pipeline; this command only reviews planning documents.

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "metaswarm",
-  "version": "0.11.0",
-  "description": "Multi-agent orchestration framework — 18 agents, 13 skills, quality gates, TDD enforcement",
+  "version": "0.12.0",
+  "description": "Multi-agent orchestration framework — 18 agents, 14 skills, quality gates, TDD enforcement",
   "contextFileName": "GEMINI.md"
 }

--- a/lib/sync-resources.js
+++ b/lib/sync-resources.js
@@ -86,6 +86,11 @@ function hashFile(filepath) {
 // --- TOML command generation ---
 // Generate Gemini TOML commands from Claude markdown commands
 
+// Note: `codex-plan-review` is intentionally NOT mapped here. The command
+// orchestrates a `codex exec` loop that requires the Codex CLI installed
+// locally — Gemini CLI users wouldn't have that environment, so we don't
+// expose a `/metaswarm:codex-plan-review` shortcut for them. The Codex
+// command file (`commands/codex-plan-review.md`) ships only for Claude.
 const TOML_COMMAND_MAP = {
   'start-task': {
     description: 'Begin tracked work on a task with complexity assessment',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaswarm",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Cross-platform installer for metaswarm — multi-agent orchestration for Claude Code, Codex CLI, and Gemini CLI",
   "bin": {
     "metaswarm": "cli/metaswarm.js"

--- a/skills/setup/templates/AGENTS.md
+++ b/skills/setup/templates/AGENTS.md
@@ -38,6 +38,7 @@ Codex discovers skills by their SKILL.md `name` field. Invoke with `$name` synta
 | `$pr-shepherd` | Monitor a PR through to merge |
 | `$handling-pr-comments` | Handle PR review comments |
 | `$create-issue` | Create a well-structured GitHub Issue |
+| `$spec-gap-review` | Audit a spec or design doc against repo reality |
 | `$external-tools` | External AI tool delegation |
 | `$status` | Run diagnostic checks |
 | `$visual-review` | Playwright screenshot capture |

--- a/skills/setup/templates/CLAUDE-append.md
+++ b/skills/setup/templates/CLAUDE-append.md
@@ -20,6 +20,7 @@ This project uses [metaswarm](https://github.com/dsifry/metaswarm) for multi-age
 | `/handle-pr-comments` | Handle PR review comments |
 | `/brainstorm` | Refine an idea before implementation |
 | `/create-issue` | Create a well-structured GitHub Issue |
+| `/codex-plan-review` | Iterative Codex review of an implementation plan (requires Codex CLI + `npx metaswarm init --codex`) |
 
 ### Quality Gates
 

--- a/skills/setup/templates/CLAUDE.md
+++ b/skills/setup/templates/CLAUDE.md
@@ -36,6 +36,7 @@ This triggers the full pipeline: Research → Plan → Design Review Gate → Wo
 | `/brainstorm` | Refine an idea before implementation |
 | `/create-issue` | Create a well-structured GitHub Issue |
 | `/external-tools-health` | Check status of external AI tools (Codex, Gemini) |
+| `/codex-plan-review` | Iterative Codex review of an implementation plan (requires Codex CLI + `npx metaswarm init --codex`) |
 | `/setup` | Interactive guided setup — detects project, configures metaswarm |
 | `/update` | Update metaswarm to latest version |
 | `/status` | Run diagnostic checks on your installation |

--- a/skills/spec-gap-review/SKILL.md
+++ b/skills/spec-gap-review/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: spec-gap-review
+description: Critical review of implementation guides, architecture docs, UX specs, infrastructure plans, memory designs, roadmaps, and other design documents against the current repository. Use when Codex needs to audit a spec for doc/code drift, missing prerequisites, stale external assumptions, schema or contract mismatches, or phase readiness; run a stable rubric, score readiness, cite file:line evidence, and prioritize problems instead of confirming that the document looks good.
+---
+
+# Spec Gap Review
+
+Review a document against implementation reality, not against its own aspirations. Prefer finding misleading completeness, infeasible sequencing, stale assumptions, and contract drift over summarizing what the document says.
+
+## Review Contract
+
+Every run must produce:
+
+- `Overall readiness` out of `100`
+- `Quality` out of `100`
+- `Completeness` out of `100`
+- The fixed core rubric scores below
+- A small set of doc-type focus checks
+- A round-aware improvement path to `100`
+
+Do not replace the core rubric with an ad hoc checklist. Tailor the findings, not the scorecard.
+
+## Workflow
+
+1. Classify the target document.
+   Typical classes: strategy, implementation guide, memory design, UX/API contract, infrastructure/deployment plan, long-lived/background-agent plan.
+2. Run the stable core rubric first.
+   Read [references/rubric-patterns.md](references/rubric-patterns.md) when you want doc-type focus checks and common failure modes.
+3. Add `2-4` doc-type focus checks.
+   These checks deepen the review but do not replace the core scorecard. Keep them unscored unless the user explicitly asks for extra scoring.
+   For implementation guides, strongly prefer:
+   - intra-doc consistency
+   - producer → carrier → consumer trace for new fields or telemetry
+   - command/artifact operability
+   - upstream status truthfulness
+4. Ground the review in local reality first.
+   Read the target doc, then check the current repo surface it claims to describe.
+   Typical hotspots:
+   - `package.json`
+   - `src/`
+   - `tests/`
+   - `.claude/agents/`
+   - sample artifacts such as `reviews/`
+   - current types and schemas in `src/types/`
+5. Run an explicit intra-doc consistency sweep.
+   Compare the document's own types, pseudocode, commands, examples, file lists, validation steps, and acceptance criteria against each other.
+   Prefer finding doc-vs-doc contradictions that would mislead an implementer, even when the repo has not been touched yet.
+6. For each newly introduced counter, schema field, telemetry field, or status enum, trace the full producer → carrier → consumer path.
+   Verify the doc defines:
+   - where the value is produced
+   - where it is stored or returned
+   - how it is threaded through intermediate types or configs
+   - where it is finally rendered, consumed, or asserted
+   Do not treat a field as "specified" if any hop is missing.
+7. Check volatile external claims only when needed.
+   Browse only for unstable or authoritative facts such as API limits, pricing, model capabilities, product approvals, regulations, or vendor docs.
+   Prefer official or primary sources.
+   Include exact dates in the report when a claim is time-sensitive.
+8. Verify upstream status claims whenever the document says another doc, design, PR, bead, phase, or gate is `approved`, `ready`, `closed`, `in progress`, or similar.
+   Check the referenced source's current status line and, when available, its latest sibling companion review instead of trusting the target doc's narration.
+9. For later-round reviews, compare against the latest prior review for the same doc.
+   Look for sibling `*-codexreview.md` files, earlier review sections, or user-provided prior reviews.
+   Carry forward unresolved gap IDs.
+   Only award recovered points when the document or repo evidence actually changed.
+10. Write a critical report.
+   Make findings primary.
+   Distinguish clearly between:
+   - what the current repo does
+   - what the document claims
+   - what is merely future intent
+11. Validate every file:line reference if you save a review file.
+   Use the bundled validator script after writing markdown with `#L...` links.
+
+## Core Rubric
+
+Score every dimension on `0-5`. Convert the score to points with `(score / 5) * weight`.
+
+| Dimension | Weight | Full-credit standard |
+| --- | ---: | --- |
+| Scope clarity and decision usefulness | 15 | The document makes the intended change, boundaries, assumptions, and decisions unambiguous. |
+| Completeness of behavior, flows, and edge cases | 20 | Happy paths, failure paths, lifecycle states, and edge cases are covered without material blind spots. |
+| Contract and schema specificity | 15 | Interfaces, schemas, invariants, and data ownership are precise enough to implement and test. |
+| Repo alignment and current-state accuracy | 20 | Claims about the current codebase, files, types, scripts, and capabilities match reality. |
+| Technical feasibility and dependency realism | 15 | Dependencies, prerequisites, external services, and migration assumptions are realistic and available. |
+| Sequencing, verification, and operational readiness | 15 | The plan can be executed safely, tested clearly, and operated without hidden prerequisite work. |
+
+### Score Meanings
+
+- `0/5`: Missing or unsupported.
+- `1/5`: Actively misleading for implementation.
+- `2/5`: Exploratory and useful for ideas, but not safe as a build spec.
+- `3/5`: Usable with material cleanup.
+- `4/5`: Mostly implementation-ready, with limited tightening needed.
+- `5/5`: Implementation-ready, evidenced, and aligned with the repo.
+
+## Rollups
+
+- `Overall readiness /100` = sum of all weighted points.
+- `Quality /100` = normalized weighted subtotal of:
+  - scope clarity and decision usefulness
+  - repo alignment and current-state accuracy
+  - technical feasibility and dependency realism
+  - sequencing, verification, and operational readiness
+- `Completeness /100` = normalized weighted subtotal of:
+  - completeness of behavior, flows, and edge cases
+  - contract and schema specificity
+  - sequencing, verification, and operational readiness
+
+Do not award `100/100` unless:
+
+- every core rubric dimension is `5/5`
+- no `P0` or `P1` issue remains open
+- all major claims are backed by repo evidence or dated external sources
+- the plan includes a concrete verification path
+
+## Multi-Round Progression
+
+When reviewing the same plan across multiple rounds:
+
+- Mark the first pass as `Round 1 - Baseline`.
+- Create stable gap IDs such as `G01`, `G02`, `G03`.
+- On later rounds, keep the same gap ID if the issue still exists.
+- Mark each gap as `closed`, `partial`, `open`, or `new`.
+- Show score deltas for:
+  - `Overall readiness`
+  - `Quality`
+  - `Completeness`
+  - each core rubric dimension
+- Include a `Path to 100` section that lists the exact missing evidence or revisions needed to recover the remaining points.
+- Keep the recommended next actions capped at the `5` highest-leverage fixes.
+- If a prior review is unavailable, say so explicitly and treat the run as a new baseline.
+
+## Review Standards
+
+- Treat the document as a spec unless it is clearly labeled brainstorming.
+- Penalize docs that present future-state design as current behavior.
+- Penalize duplicated schema definitions that can silently drift.
+- Penalize precise external quotas or pricing embedded without date/source hygiene.
+- Penalize command examples, CLI invocations, file paths, and artifact locations that cannot be executed or committed as written.
+- Penalize intra-doc inconsistencies with the same seriousness as doc-vs-repo drift when they would mislead implementation.
+- Penalize new counters or telemetry fields that lack a complete producer → carrier → consumer path.
+- Prefer repo evidence over narrative confidence.
+- Call out when a migration plan starts from an imagined baseline instead of the actual codebase.
+- When a document is conceptually good but operationally weak, say so directly.
+- Do not hide low scores behind a flattering summary.
+- Do not mark a gap closed just because the document acknowledges it. Close it only when the spec actually resolves it.
+- Do not keep re-penalizing a deliberate design choice just because an alternative might be better. If the choice is internally consistent, repo-aligned, and operationally workable, treat it as a tradeoff, not a standing gap.
+
+## Critical-Only Mode
+
+If the user asks to focus on critical errors, correctness issues, blockers, or "not nitpicks":
+
+- Prioritize open `P0` and `P1` issues only.
+- Include `P2` only when it is factually incorrect, contradicts the repo, or blocks execution/validation.
+- Compress or omit praise, closed-gap recap, and non-blocking cleanup commentary.
+- Keep the scorecard and rollups, but let the findings section stay short if only a few critical issues remain.
+
+## Output Shape
+
+Use this structure unless the user asks for a different format:
+
+1. `Round status`: round number, prior review reference if any, and whether this is a baseline or delta review.
+2. `Executive summary`: `2-3` sentences.
+3. `Rollups`: `Overall readiness`, `Quality`, `Completeness`, and score deltas when applicable.
+4. `Core scorecard`: every rubric dimension with `score`, `weight`, `points`, and `delta`.
+5. `Gap tracker`: stable gap IDs with status (`closed`, `partial`, `open`, `new`) and points recoverable.
+6. `Detailed findings`: grouped by rubric area with file:line references.
+7. `Prioritized issues`: `P0` to `P3`.
+8. `Path to 100`: exact changes needed to recover the remaining points.
+9. `Recommended next actions`: the smallest set of changes most likely to move the score materially next round.
+
+## Severity Model
+
+- `P0`: Fundamentally wrong or dangerous for implementation.
+- `P1`: Will cause real delivery, correctness, or maintenance problems.
+- `P2`: Important quality gap that should be fixed before the next phase.
+- `P3`: Nice to have or cleanup.
+
+## Score Bands
+
+- `<60`: Not safe as a build spec.
+- `60-79`: Directionally useful, but still high-risk.
+- `80-94`: Usable with material cleanup.
+- `95-99`: Nearly implementation-ready.
+- `100`: Implementation-ready and fully evidenced for the current repo state.
+
+## Saving Review Files
+
+When the user wants written feedback in-repo:
+
+- Save next to the source doc with suffix `-codexreview.md` unless the user specifies otherwise.
+- If a sibling `-codexreview.md` already exists and the user asks to save the latest review, update that file in place with a new round-aware delta review unless the user explicitly asks for a separate file.
+- Keep the report self-contained.
+- After writing, run:
+
+```bash
+python3 scripts/validate_line_links.py <review-file> [<review-file> ...]
+```
+
+- Fix any out-of-range or missing targets before closing.
+
+## Reporting Tips by Doc Type
+
+- Implementation guide:
+  Use focus checks for intra-doc consistency, producer/carrier/consumer trace for new fields, command/CLI consistency, git/artifact operability, upstream gate/status truthfulness, and whether the migration starts from the code that exists.
+- Strategy:
+  Use focus checks for API assumptions, architecture realism, domain coverage, phase sequencing, and whether the roadmap starts from the code that exists.
+- Memory:
+  Use focus checks for schema correctness, privacy/isolation, SQL validity, storage/backend claims, and operational prerequisites.
+- UX/API:
+  Use focus checks for contract realism, request/response drift, schema duplication, resume/error claims, and sample output integrity.
+- Infrastructure:
+  Use focus checks for project-structure drift, scripts and config realism, storage/auth/deploy prerequisites, and stale pricing/quota claims.
+- Long-lived agent plans:
+  Use focus checks for baseline assumptions, prerequisite systems, migration usefulness, checkpoint/job realism, and evaluation/self-improvement claims.
+
+## References
+
+- Read [references/rubric-patterns.md](references/rubric-patterns.md) when you want doc-type focus checks, common failure modes, and gap-recovery ideas.
+- Use `scripts/validate_line_links.py` to check saved markdown references deterministically.

--- a/skills/spec-gap-review/SKILL.md
+++ b/skills/spec-gap-review/SKILL.md
@@ -20,6 +20,30 @@ Every run must produce:
 
 Do not replace the core rubric with an ad hoc checklist. Tailor the findings, not the scorecard.
 
+## Depth Gates
+
+Use the normal workflow for baseline reviews. Escalate to breakthrough mode when ordinary review depth is unlikely to move the document meaningfully closer to `100`.
+
+Enter breakthrough mode when any of these are true:
+
+- the same document has had `2+` prior reviews
+- the score is `90+` but below `100`
+- the user says the plan is stuck, asks for a deep dive, or asks how to break through
+- an open or partial gap repeats across rounds
+- the `Path to 100` would otherwise repeat prior advice without new evidence
+
+Breakthrough mode requires:
+
+- reread the full target document, not only changed sections
+- reread the latest prior review and every open or partial gap ID
+- inspect every repo surface named by the plan, plus adjacent tests, schemas, scripts, configs, generated/sample artifacts, and ignore rules when relevant
+- build a claim/contract matrix for fields, commands, statuses, APIs, artifacts, acceptance criteria, and externally sourced facts
+- explain why prior rounds did not reach `100`
+- split repeated partial gaps into exact missing edits or evidence
+- make the `Path to 100` patch-grade, not advisory
+
+Do not finish breakthrough mode with generic advice. Every remaining point must map to a concrete missing document change, repo verification, or external source check.
+
 ## Workflow
 
 1. Classify the target document.
@@ -52,24 +76,47 @@ Do not replace the core rubric with an ad hoc checklist. Tailor the findings, no
    - how it is threaded through intermediate types or configs
    - where it is finally rendered, consumed, or asserted
    Do not treat a field as "specified" if any hop is missing.
-7. Check volatile external claims only when needed.
+7. Build a claim/contract matrix when the plan introduces or revises contracts.
+   Use a compact table with:
+   `Claim | Producer | Carrier | Consumer | Verification | Evidence | Status`.
+   Include rows for new fields, status enums, commands, API surfaces, artifacts, acceptance criteria, upstream statuses, and dated external claims.
+   Omit the table only when the document truly has no contract-like claims.
+8. Check volatile external claims only when needed.
    Browse only for unstable or authoritative facts such as API limits, pricing, model capabilities, product approvals, regulations, or vendor docs.
    Prefer official or primary sources.
    Include exact dates in the report when a claim is time-sensitive.
-8. Verify upstream status claims whenever the document says another doc, design, PR, bead, phase, or gate is `approved`, `ready`, `closed`, `in progress`, or similar.
+9. Verify upstream status claims whenever the document says another doc, design, PR, bead, phase, or gate is `approved`, `ready`, `closed`, `in progress`, or similar.
    Check the referenced source's current status line and, when available, its latest sibling companion review instead of trusting the target doc's narration.
-9. For later-round reviews, compare against the latest prior review for the same doc.
+10. For later-round reviews, compare against the latest prior review for the same doc.
    Look for sibling `*-codexreview.md` files, earlier review sections, or user-provided prior reviews.
    Carry forward unresolved gap IDs.
    Only award recovered points when the document or repo evidence actually changed.
-10. Write a critical report.
+   If a gap remains partial after `2` rounds, split it into concrete sub-gaps.
+   If the same recommendation appears twice, replace it with exact missing edits and evidence.
+   Every open gap must explain why the prior attempted fix was insufficient.
+11. Apply score caps before finalizing scores.
+   Caps are ceilings, not automatic scores; lower scores may still be warranted.
+12. Run an adversarial final pass.
+   Ask what would make an implementer waste a day, what assumption could break the next phase, what appears only once, what is future intent disguised as current state, what a test writer could not assert, and what a PR reviewer would challenge.
+13. Write a critical report.
    Make findings primary.
    Distinguish clearly between:
    - what the current repo does
    - what the document claims
    - what is merely future intent
-11. Validate every file:line reference if you save a review file.
+14. Validate every file:line reference if you save a review file.
    Use the bundled validator script after writing markdown with `#L...` links.
+
+## Minimum Repo Exploration
+
+Do not treat these as optional when they match the document type. If a surface is absent, cite that as evidence instead of silently skipping it.
+
+- Implementation guide: inspect target modules, adjacent tests, package scripts, types or schemas, CLI entrypoints, generated or sample artifacts, and `.gitignore` paths for claimed commit artifacts.
+- Strategy: inspect current architecture entrypoints, existing capabilities, package scripts, major source directories, tests, and any named upstream docs or decisions.
+- Memory or knowledge-system doc: inspect persistence code, migrations or schema, query layer, isolation/privacy boundaries, lifecycle jobs, and test fixtures.
+- UX/API contract: inspect request/response types, API routes or CLI output, renderer/output code, tests, examples, and resume/error handling paths.
+- Infrastructure/deployment plan: inspect scripts, config, deploy files, environment docs, storage/auth/runtime layers, and cost/quota claims that need current sources.
+- Long-lived/background-agent plan: inspect persistence and recovery primitives, job/checkpoint abstractions, instrumentation hooks, schema assumptions, and evaluation loops.
 
 ## Core Rubric
 
@@ -113,6 +160,29 @@ Do not award `100/100` unless:
 - all major claims are backed by repo evidence or dated external sources
 - the plan includes a concrete verification path
 
+To award `100`, prove implementation readiness from the perspective of a fresh engineer starting the work tomorrow. The review must show that:
+
+- every named current file exists, or every future file is clearly introduced as new work
+- every new field, status, counter, API, command, and artifact has a complete producer → carrier → consumer → verification path
+- every command can run as written, or is explicitly marked as future after the prerequisite step that creates it
+- every acceptance criterion maps to a concrete verification step
+- every upstream dependency has a current status check
+- every phase starts from the actual current repo state
+- no unresolved contradiction remains between prose, types, examples, tests, commands, artifacts, and revision logs
+
+### Score Caps
+
+Apply these caps consistently:
+
+- Any unverified current-state repo claim caps repo alignment at `3/5`.
+- Any migration that starts from an imagined baseline caps repo alignment at `2/5`.
+- Any required field, counter, status, API, command, or artifact missing a producer/carrier/consumer/verification hop caps contract specificity at `3/5`.
+- Any command or artifact path that cannot work as written caps sequencing, verification, and operational readiness at `3/5`.
+- Any stale or unsourced volatile external fact that drives design choices caps technical feasibility at `3/5`.
+- Any open `P1` caps overall readiness below `95`.
+- Any repeated unresolved `P1` across rounds caps overall readiness below `90` unless the review narrows it into exact remaining edits and evidence.
+- Any unresolved `P0` caps overall readiness below `80`.
+
 ## Multi-Round Progression
 
 When reviewing the same plan across multiple rounds:
@@ -129,6 +199,30 @@ When reviewing the same plan across multiple rounds:
 - Include a `Path to 100` section that lists the exact missing evidence or revisions needed to recover the remaining points.
 - Keep the recommended next actions capped at the `5` highest-leverage fixes.
 - If a prior review is unavailable, say so explicitly and treat the run as a new baseline.
+
+## Gap Closure Rules
+
+Do not mark a gap `closed` merely because the document acknowledges it, promises later work, or says the revision fixed it. Close a gap only when the spec actually resolves the implementation risk with aligned prose, contracts, examples, commands, tests, artifacts, and repo evidence as applicable.
+
+Common false-closure signals:
+
+- the fix appears only in the revision log
+- one example changed but the canonical contract still drifts
+- the plan says "handled later" without sequencing and verification
+- the fix introduces a new undefined field, term, phase, command, status, or prerequisite
+- implementation evidence exists only in prose, not in the relevant types, commands, tests, artifacts, or source references
+
+## Path to 100 Standard
+
+Make `Path to 100` patch-grade. Each item must name:
+
+- the exact document section or contract to revise
+- the exact repo evidence, upstream status, or external source needed
+- the command, schema, field, artifact, or acceptance criterion to normalize
+- the verification command or assertion expected after revision
+- the approximate points recoverable
+
+Avoid vague advice such as "clarify verification" or "tighten sequencing." Replace it with the exact missing edit or evidence that would recover the score.
 
 ## Review Standards
 
@@ -164,10 +258,12 @@ Use this structure unless the user asks for a different format:
 3. `Rollups`: `Overall readiness`, `Quality`, `Completeness`, and score deltas when applicable.
 4. `Core scorecard`: every rubric dimension with `score`, `weight`, `points`, and `delta`.
 5. `Gap tracker`: stable gap IDs with status (`closed`, `partial`, `open`, `new`) and points recoverable.
-6. `Detailed findings`: grouped by rubric area with file:line references.
-7. `Prioritized issues`: `P0` to `P3`.
-8. `Path to 100`: exact changes needed to recover the remaining points.
-9. `Recommended next actions`: the smallest set of changes most likely to move the score materially next round.
+6. `Breakthrough notes`: include only when breakthrough mode was triggered; explain why prior rounds stalled and what deeper evidence changed the review.
+7. `Claim/contract matrix`: include when the document has contract-like claims.
+8. `Detailed findings`: grouped by rubric area with file:line references.
+9. `Prioritized issues`: `P0` to `P3`.
+10. `Path to 100`: exact changes needed to recover the remaining points.
+11. `Recommended next actions`: the smallest set of changes most likely to move the score materially next round.
 
 ## Severity Model
 

--- a/skills/spec-gap-review/agents/openai.yaml
+++ b/skills/spec-gap-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Spec Gap Review"
+  short_description: "Audit specs against repo reality"
+  default_prompt: "Use $spec-gap-review to review this design doc against the current codebase and rate its implementation readiness."

--- a/skills/spec-gap-review/references/rubric-patterns.md
+++ b/skills/spec-gap-review/references/rubric-patterns.md
@@ -1,0 +1,275 @@
+# Rubric Patterns
+
+Always run the fixed core rubric from `SKILL.md` first. Do not replace it with a doc-specific scorecard.
+
+Use the material below to choose `2-4` doc-type focus checks that deepen the review without breaking score comparability across runs.
+
+## Cross-Cutting Patterns
+
+Use these patterns across doc types when the document introduces new contracts, new commands, or multi-round revisions.
+
+### Intra-Doc Consistency
+
+Suggested focus checks:
+
+- CLI flags and examples agree with the declared contract
+- Type snippets agree with later pseudocode and tests
+- Validation steps use the same filenames, paths, and commands named earlier
+- Revision-log claims agree with the body of the document
+
+Common failure modes:
+
+- One section says `--seed`, later commands use `--seed-doi`
+- A renderer example emits fields never added to the schema/type snippet
+- A later work unit relies on a field the earlier type contract never introduced
+- A revision log says a gap is fixed, but the body still contains the old contract
+
+Typical path-to-100 upgrades:
+
+- Pick one canonical flag/path/type spelling and use it everywhere
+- Update all snippets when a contract changes, not just the prose summary
+- Treat doc-vs-doc contradictions as real blockers when they would mislead implementation
+
+### Producer → Carrier → Consumer Trace
+
+Suggested focus checks:
+
+- New counters have a producer
+- New fields have a declared storage or return location
+- Intermediate configs/types thread the value through every hop
+- Final output/tests/renderers actually consume the value
+
+Common failure modes:
+
+- A field appears in `pipeline_health` output examples but has no producer
+- A counter exists in initialization defaults but not in the type definition
+- A state populates only a subset of the fields later rendered or asserted
+- The final renderer or writer is never updated, so the field cannot surface
+
+Typical path-to-100 upgrades:
+
+- For every new field, name the producer, carrier, and consumer explicitly
+- Use one canonical stats object instead of scattering related fields
+- Verify output examples only mention values that the proposed code path can actually produce
+
+### Command And Artifact Operability
+
+Suggested focus checks:
+
+- Commands match the current or newly declared CLI contract
+- Artifact paths are writable, visible, and committable as claimed
+- Validation steps can run in the repo as written
+- Commit steps only reference repo-tracked artifacts
+
+Common failure modes:
+
+- Examples use renamed flags before the CLI contract is updated
+- The document calls a path "repo-tracked" even though `.gitignore` excludes it
+- Validation steps write to `/tmp` and later tell the implementer to `git add` the output
+- Manual smoke tests use different commands than the earlier work-unit contract
+
+Typical path-to-100 upgrades:
+
+- Normalize all commands to one CLI shape
+- Check `.gitignore` before calling any output path "tracked"
+- Move summaries or reduced artifacts into real repo paths before commit steps
+
+### Upstream Status Truthfulness
+
+Suggested focus checks:
+
+- Referenced design/spec/gate status matches the current source
+- Companion-review conclusions are not silently overridden by the target doc
+- Prerequisite beads/issues/PRs are in the state the doc claims
+
+Common failure modes:
+
+- A plan says a design is approved when the design still says "pending re-review"
+- A revision log dismisses a prior finding without actually fixing the contract
+- A prerequisite is described as complete when the tracker still says `open` or `in_progress`
+
+Typical path-to-100 upgrades:
+
+- Check the current status line of every upstream doc the plan relies on
+- Check the latest sibling `-codexreview.md` when status claims are disputed
+- Rewrite status language to match current repo truth, not a prior intention
+
+### Critical-Only Reviews
+
+Use when the user asks for blockers, correctness issues, or "not nitpicks."
+
+Guidance:
+
+- Prefer open `P0` and `P1` only
+- Include `P2` only when it is factually wrong or blocks execution
+- Compress praise and closed-gap recap
+- Keep the scorecard, but let the findings stay short
+
+### Coherent Design Choice Handling
+
+Guidance:
+
+- Do not keep re-raising a deliberate design tradeoff as an "open gap" if it is internally consistent, repo-aligned, and operationally workable
+- Distinguish:
+  - unsupported or contradictory design
+  - consistent but arguable design choice
+- If you disagree with the choice, note the tradeoff once and move on unless it creates a concrete implementation risk
+
+## Implementation / Migration Docs
+
+Suggested focus checks:
+
+- Intra-doc consistency
+- Producer → carrier → consumer trace for new fields
+- CLI and command operability
+- Artifact and git-tracking realism
+- Upstream gate/status truthfulness
+- Migration usefulness from the actual repo baseline
+
+Common failure modes:
+
+- Type snippets, pseudocode, and tests disagree on the same contract
+- New telemetry fields lack a full thread-through path
+- Validation commands use different flags than the stated CLI contract
+- Commit steps reference ignored or non-repo artifacts
+- The document starts from a richer baseline than the repo actually has
+
+Typical path-to-100 upgrades:
+
+- Add one canonical contract section and keep all examples aligned to it
+- Trace each new field from producer to final consumer
+- Make validation commands executable and committable as written
+- Verify every upstream readiness claim against the referenced source
+- Start migration steps from the current code and explicitly name prerequisites
+
+## Strategy Docs
+
+Suggested focus checks:
+
+- API and data-source strategy
+- Architecture realism
+- Domain and search strategy
+- Output and quality contract
+- Phase plan and decision usefulness
+
+Common failure modes:
+
+- Future-state architecture written as current plan
+- Volatile vendor facts treated as fixed design constants
+- Domain tables assumed current but not maintained
+- Phase plan starts from capabilities the repo does not have
+
+Typical path-to-100 upgrades:
+
+- Separate current state from target state explicitly
+- Tie every phase to code or infra that already exists, or call out prerequisite work
+- Replace static vendor claims with dated sources
+
+## Memory / Knowledge-System Docs
+
+Suggested focus checks:
+
+- Memory model and taxonomy
+- Schema and query correctness
+- Multi-tenant and privacy design
+- Operational feasibility
+- Phase planning
+
+Common failure modes:
+
+- `user_id` missing on user-scoped tables
+- SQL examples invalid for stated backend
+- Privacy promises unsupported by schema
+- “Same schema, different backend” claims that are not actually true
+
+Typical path-to-100 upgrades:
+
+- Make ownership, isolation, and retention rules explicit
+- Validate sample queries against the real backend
+- Show how migration and backfill work in the current system
+
+## UX / API Contract Docs
+
+Suggested focus checks:
+
+- CLI UX realism
+- Web API contract readiness
+- Output schema alignment
+- Graph/data contract realism
+- Memory-informed UX realism
+- Error, resume, and iteration model
+
+Common failure modes:
+
+- Unimplemented REST or SSE surface presented as current
+- Canonical schema in docs diverges from `src/types`
+- Optional exports or interactions promised but unsupported
+- Resume, cancellation, or timeout claims assume persistence that does not exist
+
+Typical path-to-100 upgrades:
+
+- Point every contract claim to a canonical schema or type location
+- Specify failure and retry behavior, not just happy paths
+- Separate aspirational UX from supported UX
+
+## Infrastructure / Deployment Docs
+
+Suggested focus checks:
+
+- Repo and project-structure alignment
+- Storage and database realism
+- Auth and deployment readiness
+- Observability and operations planning
+- Cost and external dependency accuracy
+
+Common failure modes:
+
+- Fictional directories, scripts, or deploy assets
+- Database or auth plan depends on missing runtime layers
+- Pricing and quotas stale
+- Local and production behavior conflated
+
+Typical path-to-100 upgrades:
+
+- Validate every named script, directory, and deploy artifact in the repo
+- Describe missing runtime layers as prerequisites instead of assuming them
+- Date-stamp vendor cost and quota claims
+
+## Long-Lived / Background-Agent Docs
+
+Suggested focus checks:
+
+- Durable execution design
+- Background-agent architecture
+- Self-improvement loop
+- Prerequisite and schema realism
+- Migration usefulness
+
+Common failure modes:
+
+- Migration starts from a richer imagined baseline than the actual code
+- Checkpointing or job plans assume missing primitives
+- Self-improvement claims have no instrumentation or prompt/runtime hooks
+- Cross-doc schema assumptions are already false
+
+Typical path-to-100 upgrades:
+
+- Anchor long-running claims to actual persistence and recovery primitives
+- Show what instrumentation exists versus what must be added
+- Break “self-improvement” into concrete measurable loops
+
+## Report Skeleton
+
+Use this structure unless the user requests something else:
+
+1. `Round status`
+2. `Executive summary`
+3. `Rollups`
+4. `Core scorecard`
+5. `Gap tracker`
+6. `Detailed findings by rubric area`
+7. `Prioritized issue list` (`P0`-`P3`)
+8. `Path to 100`
+9. `Recommended next actions`
+
+Keep the tone critical and implementation-facing.

--- a/skills/spec-gap-review/references/rubric-patterns.md
+++ b/skills/spec-gap-review/references/rubric-patterns.md
@@ -8,6 +8,104 @@ Use the material below to choose `2-4` doc-type focus checks that deepen the rev
 
 Use these patterns across doc types when the document introduces new contracts, new commands, or multi-round revisions.
 
+### Breakthrough Mode For Stuck Reviews
+
+Use when a review is late-round, high-scoring but not complete, or repeating prior advice.
+
+Required moves:
+
+- Reread the full target doc and latest prior review before scoring.
+- List every open or partial gap ID and state whether the current document changed the relevant evidence.
+- Inspect the repo surfaces that would prove or disprove each gap, including adjacent tests and generated/sample artifacts.
+- Convert repeated broad gaps into narrower sub-gaps that identify the exact missing section, command, field, source, or assertion.
+- Add a short diagnosis of why earlier rounds stalled.
+
+Common reasons rounds stall:
+
+- The review keeps accepting revision-log claims instead of rereading the canonical body.
+- The gap is acknowledged but not resolved in the executable contract.
+- Examples were updated but types, commands, or tests still use the old shape.
+- The plan remains internally coherent but starts from a repo baseline that does not exist.
+- The `Path to 100` says what quality is missing but not what edit would prove it.
+
+Typical path-to-100 upgrades:
+
+- Replace "clarify" with exact edits to a named section or contract.
+- Replace "add tests" with the command, assertion, fixture, and expected artifact.
+- Replace "verify upstream" with the exact source file, PR, bead, status line, or external official page to check.
+- Split a recurring partial gap into independently closable evidence gaps.
+
+### Claim / Contract Matrix
+
+Use for any doc that introduces or changes fields, statuses, APIs, commands, artifacts, acceptance criteria, upstream status claims, or volatile external facts.
+
+Suggested columns:
+
+| Claim | Producer | Carrier | Consumer | Verification | Evidence | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| New output field | Function/event that creates it | Type/schema/config/artifact that stores or passes it | Renderer/API/test/user-facing output | Test/command/assertion | Repo file:line or dated source | open/partial/closed |
+
+Common failure modes:
+
+- A field has a producer and example output but no carrier type.
+- A command appears in validation steps before the CLI contract defines it.
+- An artifact is rendered but never made writable, tracked, or referenced by commit steps.
+- An acceptance criterion is clear but has no verification command.
+- An upstream approval claim has no current source check.
+
+Typical path-to-100 upgrades:
+
+- Add a canonical contract section and make all snippets point to it.
+- Thread every field through producer, carrier, consumer, and verification.
+- Mark future commands as unavailable until the work unit that creates them.
+- Remove matrix rows from examples unless the proposed path can produce them.
+
+### Score Cap Calibration
+
+Use caps as ceilings, then score lower when the actual evidence is worse.
+
+Common caps:
+
+- Unverified current-state repo claims cap repo alignment at `3/5`.
+- Imagined repo baseline caps repo alignment at `2/5`.
+- Missing producer/carrier/consumer/verification hop caps contract specificity at `3/5`.
+- Non-executable commands or impossible artifact paths cap operational readiness at `3/5`.
+- Stale or unsourced volatile external facts that drive decisions cap feasibility at `3/5`.
+- Any open `P1` caps overall readiness below `95`; repeated unresolved `P1` caps below `90` unless narrowed.
+- Any unresolved `P0` caps overall readiness below `80`.
+
+Typical path-to-100 upgrades:
+
+- State the cap explicitly in the scorecard note.
+- Identify the exact evidence needed to lift the cap.
+- Do not recover points for acknowledgements, only for corrected contracts or verified sources.
+
+### Patch-Grade Path To 100
+
+Weak path item:
+
+- "Clarify verification."
+
+Strong path item:
+
+- "In `Verification`, map AC-03 to `npm test -- --run pipeline-health`, update examples to the canonical `--review-id` flag, and state the expected artifact at `reviews/<id>/summary.json` so the acceptance criterion is executable. Recoverable: `3` points."
+
+Weak path item:
+
+- "Resolve producer/consumer gaps."
+
+Strong path item:
+
+- "In `Telemetry Contract`, add the producer for `pipeline_health.missingFields`, thread it through the stats type used by the writer, and add a renderer assertion that the field appears only when populated. Recoverable: `4` points."
+
+Checklist for every path item:
+
+- Names exact doc location.
+- Names exact repo evidence or source check.
+- Names exact field, command, artifact, or criterion.
+- Names verification.
+- Names recoverable points.
+
 ### Intra-Doc Consistency
 
 Suggested focus checks:

--- a/skills/spec-gap-review/scripts/validate_line_links.py
+++ b/skills/spec-gap-review/scripts/validate_line_links.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Validate markdown links that point to absolute file paths with optional #L anchors."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+LINK_RE = re.compile(r"\]\((/[^)#]+)(?:#L(\d+)(?:C\d+)?)?\)")
+
+
+def validate_file(md_path: Path) -> list[str]:
+    errors: list[str] = []
+    text = md_path.read_text()
+    for match in LINK_RE.finditer(text):
+        target = Path(match.group(1))
+        line = int(match.group(2)) if match.group(2) else None
+
+        if not target.exists():
+            errors.append(f"{md_path}: missing target {target}")
+            continue
+
+        if line is not None:
+            total = sum(1 for _ in target.open())
+            if not (1 <= line <= total):
+                errors.append(f"{md_path}: {target}#L{line} out of range (1..{total})")
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: validate_line_links.py <markdown-file> [<markdown-file> ...]", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    checked = 0
+    for arg in argv[1:]:
+        md_path = Path(arg)
+        if not md_path.exists():
+            errors.append(f"missing markdown file {md_path}")
+            continue
+        checked += 1
+        errors.extend(validate_file(md_path))
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print(f"validated {checked} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/skills/spec-gap-review/scripts/validate_line_links.py
+++ b/skills/spec-gap-review/scripts/validate_line_links.py
@@ -13,7 +13,7 @@ LINK_RE = re.compile(r"\]\((/[^)#]+)(?:#L(\d+)(?:C\d+)?)?\)")
 
 def validate_file(md_path: Path) -> list[str]:
     errors: list[str] = []
-    text = md_path.read_text()
+    text = md_path.read_text(encoding="utf-8")
     for match in LINK_RE.finditer(text):
         target = Path(match.group(1))
         line = int(match.group(2)) if match.group(2) else None
@@ -23,7 +23,8 @@ def validate_file(md_path: Path) -> list[str]:
             continue
 
         if line is not None:
-            total = sum(1 for _ in target.open())
+            with target.open(encoding="utf-8") as f:
+                total = sum(1 for _ in f)
             if not (1 <= line <= total):
                 errors.append(f"{md_path}: {target}#L{line} out of range (1..{total})")
     return errors

--- a/skills/spec-gap-review/scripts/validate_line_links.py
+++ b/skills/spec-gap-review/scripts/validate_line_links.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Validate markdown links that point to absolute file paths with optional #L anchors."""
+"""Validate markdown links to file paths with optional #L line anchors.
+
+Supports both absolute paths (resolved as-is) and repo-relative paths
+(resolved relative to each markdown file's parent directory).
+"""
 
 from __future__ import annotations
 
@@ -8,25 +12,49 @@ import sys
 from pathlib import Path
 
 
-LINK_RE = re.compile(r"\]\((/[^)#]+)(?:#L(\d+)(?:C\d+)?)?\)")
+LINK_RE = re.compile(r"\]\(([^)#\s]+)(?:#L(\d+)(?:C\d+)?)?\)")
+URL_SCHEME_RE = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
+
+
+def _resolve_target(raw: str, md_path: Path) -> Path:
+    """Resolve a link target. Absolute paths used as-is; relative resolved against md_path's parent."""
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        return candidate
+    return (md_path.parent / candidate).resolve()
 
 
 def validate_file(md_path: Path) -> list[str]:
     errors: list[str] = []
     text = md_path.read_text(encoding="utf-8")
+    line_count_cache: dict[Path, int] = {}
+
     for match in LINK_RE.finditer(text):
-        target = Path(match.group(1))
+        raw = match.group(1)
+        if URL_SCHEME_RE.match(raw):
+            continue
+        target = _resolve_target(raw, md_path)
         line = int(match.group(2)) if match.group(2) else None
 
         if not target.exists():
             errors.append(f"{md_path}: missing target {target}")
             continue
 
-        if line is not None:
-            with target.open(encoding="utf-8") as f:
-                total = sum(1 for _ in f)
-            if not (1 <= line <= total):
-                errors.append(f"{md_path}: {target}#L{line} out of range (1..{total})")
+        if line is None:
+            continue
+
+        total = line_count_cache.get(target)
+        if total is None:
+            try:
+                with target.open(encoding="utf-8") as fh:
+                    total = sum(1 for _ in fh)
+            except (OSError, UnicodeDecodeError) as exc:
+                errors.append(f"{md_path}: cannot read {target}: {exc}")
+                continue
+            line_count_cache[target] = total
+
+        if not (1 <= line <= total):
+            errors.append(f"{md_path}: {target}#L{line} out of range (1..{total})")
     return errors
 
 

--- a/skills/start/references/platform-adaptation.md
+++ b/skills/start/references/platform-adaptation.md
@@ -48,7 +48,7 @@ Codex CLI has no subagent dispatch. All workflows run sequentially in-session:
 
 ## Command Invocation
 
-Codex uses the `name` field from SKILL.md frontmatter for `$name` invocation — not the directory name. The `metaswarm-` prefix on directory names is for organization only.
+Codex uses the `name` field from SKILL.md frontmatter for `$name` invocation — not the directory name. metaswarm installs Codex skills into `${CODEX_HOME:-$HOME/.codex}/skills/` by folder name, while invocation still comes from the frontmatter `name`.
 
 | Action | Claude Code | Gemini CLI | Codex CLI |
 |---|---|---|---|

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -38,6 +38,7 @@ Codex discovers skills by their SKILL.md `name` field. Invoke with `$name` synta
 | `$pr-shepherd` | Monitor a PR through to merge |
 | `$handling-pr-comments` | Handle PR review comments |
 | `$create-issue` | Create a well-structured GitHub Issue |
+| `$spec-gap-review` | Audit a spec or design doc against repo reality |
 | `$external-tools` | External AI tool delegation |
 | `$status` | Run diagnostic checks |
 | `$visual-review` | Playwright screenshot capture |

--- a/templates/CLAUDE-append.md
+++ b/templates/CLAUDE-append.md
@@ -20,6 +20,7 @@ This project uses [metaswarm](https://github.com/dsifry/metaswarm) for multi-age
 | `/handle-pr-comments` | Handle PR review comments |
 | `/brainstorm` | Refine an idea before implementation |
 | `/create-issue` | Create a well-structured GitHub Issue |
+| `/codex-plan-review` | Iterative Codex review of an implementation plan (requires Codex CLI + `npx metaswarm init --codex`) |
 
 ### Quality Gates
 

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -36,6 +36,7 @@ This triggers the full pipeline: Research → Plan → Design Review Gate → Wo
 | `/brainstorm` | Refine an idea before implementation |
 | `/create-issue` | Create a well-structured GitHub Issue |
 | `/external-tools-health` | Check status of external AI tools (Codex, Gemini) |
+| `/codex-plan-review` | Iterative Codex review of an implementation plan (requires Codex CLI + `npx metaswarm init --codex`) |
 | `/setup` | Interactive guided setup — detects project, configures metaswarm |
 | `/update` | Update metaswarm to latest version |
 | `/status` | Run diagnostic checks on your installation |

--- a/tests/cli/test-installer.sh
+++ b/tests/cli/test-installer.sh
@@ -52,6 +52,13 @@ else
   fail "metaswarm --help failed"
 fi
 
+# 5b. Codex installer targets the Codex skills directory
+if grep -Fq "path.join(process.env.CODEX_HOME || path.join(os.homedir(), '.codex'), 'skills')" "$ROOT/cli/metaswarm.js"; then
+  pass "cli Codex install uses \$CODEX_HOME/skills"
+else
+  fail "cli Codex install does not use \$CODEX_HOME/skills"
+fi
+
 # 6. CLI version works
 pkg_ver=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$ROOT/package.json','utf-8')).version)")
 cli_ver=$(node "$ROOT/cli/metaswarm.js" --version 2>&1)

--- a/tests/cli/test-installer.sh
+++ b/tests/cli/test-installer.sh
@@ -53,7 +53,8 @@ else
 fi
 
 # 5b. Codex installer targets the Codex skills directory
-if grep -Fq "path.join(process.env.CODEX_HOME || path.join(os.homedir(), '.codex'), 'skills')" "$ROOT/cli/metaswarm.js"; then
+if grep -Fq "const codexHome = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');" "$ROOT/cli/metaswarm.js" \
+   && grep -Fq "const skillsDir = path.join(codexHome, 'skills');" "$ROOT/cli/metaswarm.js"; then
   pass "cli Codex install uses \$CODEX_HOME/skills"
 else
   fail "cli Codex install does not use \$CODEX_HOME/skills"

--- a/tests/codex/test-codex-skills.sh
+++ b/tests/codex/test-codex-skills.sh
@@ -35,6 +35,13 @@ else
   fail "install.sh missing proper shebang"
 fi
 
+# 2b. Install script targets the Codex skills directory
+if grep -Fq 'SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"' "$ROOT/.codex/install.sh"; then
+  pass "install.sh targets \$CODEX_HOME/skills"
+else
+  fail "install.sh does not target \$CODEX_HOME/skills"
+fi
+
 # 3. AGENTS.md exists at repo root
 if [ -f "$ROOT/AGENTS.md" ]; then
   pass "AGENTS.md exists at repo root"
@@ -90,6 +97,36 @@ else
   fail ".codex/README.md not found"
 fi
 
+# 6b. README documents Codex skill installation and the new review skill
+if grep -Fq '~/.codex/skills' "$ROOT/.codex/README.md"; then
+  pass ".codex/README.md documents ~/.codex/skills"
+else
+  fail ".codex/README.md does not document ~/.codex/skills"
+fi
+
+if grep -Fq '$spec-gap-review' "$ROOT/.codex/README.md"; then
+  pass ".codex/README.md lists the spec-gap-review skill"
+else
+  fail ".codex/README.md does not list the spec-gap-review skill"
+fi
+
+# 6c. codex-plan-review command documents how to find/install its backing skill
+if [ -f "$ROOT/commands/codex-plan-review.md" ]; then
+  pass "commands/codex-plan-review.md exists"
+  if grep -Fq '${CODEX_HOME:-$HOME/.codex}/skills/spec-gap-review/SKILL.md' "$ROOT/commands/codex-plan-review.md"; then
+    pass "codex-plan-review checks the Codex home skill path"
+  else
+    fail "codex-plan-review does not check the Codex home skill path"
+  fi
+  if grep -Fq 'npx metaswarm init --codex' "$ROOT/commands/codex-plan-review.md"; then
+    pass "codex-plan-review documents how to install the skill"
+  else
+    fail "codex-plan-review does not document how to install the skill"
+  fi
+else
+  fail "commands/codex-plan-review.md not found"
+fi
+
 # 7. Template files exist
 for tmpl in AGENTS.md AGENTS-append.md; do
   if [ -f "$ROOT/templates/$tmpl" ]; then
@@ -105,7 +142,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 for skill_dir in "$ROOT/skills"/*/; do
   [ -d "$skill_dir" ] || continue
-  skill_name="metaswarm-$(basename "$skill_dir")"
+  skill_name="$(basename "$skill_dir")"
   ln -sf "$skill_dir" "$TMP_DIR/$skill_name"
 done
 

--- a/tests/codex/test-codex-skills.sh
+++ b/tests/codex/test-codex-skills.sh
@@ -36,7 +36,8 @@ else
 fi
 
 # 2b. Install script targets the Codex skills directory
-if grep -Fq 'SKILLS_DIR="${CODEX_HOME:-$HOME/.codex}/skills"' "$ROOT/.codex/install.sh"; then
+if grep -Fq 'CODEX_ROOT="${CODEX_HOME:-$HOME/.codex}"' "$ROOT/.codex/install.sh" \
+   && grep -Fq 'SKILLS_DIR="$CODEX_ROOT/skills"' "$ROOT/.codex/install.sh"; then
   pass "install.sh targets \$CODEX_HOME/skills"
 else
   fail "install.sh does not target \$CODEX_HOME/skills"


### PR DESCRIPTION
## Summary

Adds an iterative Codex-driven plan review loop and the underlying review skill, plus the v0.12.0 release polish (CHANGELOG, version bumps, doc rollout, installer hardening).

- **`/codex-plan-review`** (`commands/codex-plan-review.md`, 442 lines) — Codex reviews an implementation plan, Claude reads P0/P1 findings and patches the plan, Codex re-reviews, until all blocking issues close or max rounds hit. Three tunable profiles (`speed` / `balanced` / `quality`), profile-aware terminal conditions (ACCEPT requires score ≥ floor in `quality`), score-trajectory tracking, hang-watcher, and a `Deferred Gaps (codex)` schema for partial wins.
- **`spec-gap-review` skill** (`skills/spec-gap-review/`) — Codex-runnable critical review of implementation guides, design docs, UX specs, infrastructure plans, memory designs, and roadmaps against actual repo state. Stable 6-dimension rubric (scope clarity, behavior completeness, contract specificity, repo alignment, technical feasibility, sequencing/operability), gap IDs (G01, G02…) carried across rounds, file:line citations validated by `scripts/validate_line_links.py`, doc-type focus checks, and a Critical-Only Mode for delta rounds.
- **Codex installer hardening** (`.codex/install.sh` + `cli/metaswarm.js`) — Skills now install to `${CODEX_HOME:-$HOME/.codex}/skills/` (was `~/.agents/skills/metaswarm-*`), so symlink names match the SKILL.md `name` field directly and `\$skill-name` invocation works as documented. One-time legacy sweep removes dangling `metaswarm-*` symlinks left behind in `~/.agents/skills/` by 0.10/0.11. Real-directory conflicts now print a clear remediation hint instead of a bare warning.
- **Doc + count rollout** — `/codex-plan-review` documented in `CLAUDE.md`, `INSTALL.md`, `USAGE.md`, and the setup templates. `spec-gap-review` documented in `USAGE.md` and `AGENTS.md`. Skill/command counts updated everywhere: 13 → 14 skills, 15 → 16 commands.
- **Version bump** 0.11.0 → 0.12.0 in `package.json`, `.claude-plugin/plugin.json`, and `gemini-extension.json`. CHANGELOG entry covers Added/Changed.
- **`lib/sync-resources.js`**: explanatory comment on why `codex-plan-review` is intentionally NOT mapped into Gemini's TOML command set — it shells out to the Codex CLI, which Gemini users wouldn't have locally.

## Test plan

- [ ] `npm test` passes (covers `tests/cli/test-installer.sh` and `tests/codex/test-codex-skills.sh`)
- [ ] Fresh Codex install via `npx metaswarm init --codex` creates symlinks under `${CODEX_HOME:-\$HOME/.codex}/skills/` with un-prefixed names (e.g. `spec-gap-review`, not `metaswarm-spec-gap-review`)
- [ ] Upgrade install on a machine with leftover `~/.agents/skills/metaswarm-*` symlinks reports the legacy-sweep count and removes them
- [ ] Re-running install when a target path is a real directory prints the remediation hint and skips cleanly
- [ ] `/codex-plan-review <plan-file>` runs end-to-end against a sample plan: produces gap report, applies P0/P1 patches, re-reviews, terminates on ACCEPT or max rounds
- [ ] `scripts/validate_line_links.py` verifies file:line citations on a sample gap report
- [ ] Gemini extension load shows 14 skills / 16 commands; `/metaswarm:codex-plan-review` is intentionally absent on Gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)