### PR TITLE
Add first-class Codex plugin support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "metaswarm",
+  "interface": {
+    "displayName": "metaswarm"
+  },
+  "plugins": [
+    {
+      "name": "metaswarm",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/dsifry/metaswarm.git",
+        "ref": "main"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Coding"
+    }
+  ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,43 @@
+{
+  "name": "metaswarm",
+  "version": "0.11.0",
+  "description": "Multi-agent orchestration framework for Claude Code, Gemini CLI, and Codex CLI — 19 agents, 13 skills, quality gates, and TDD enforcement",
+  "author": {
+    "name": "David Sifry",
+    "email": "david@sifry.com"
+  },
+  "homepage": "https://github.com/dsifry/metaswarm",
+  "repository": "https://github.com/dsifry/metaswarm",
+  "license": "MIT",
+  "keywords": [
+    "orchestration",
+    "agents",
+    "tdd",
+    "quality-gates",
+    "beads",
+    "codex"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "metaswarm",
+    "shortDescription": "Multi-agent orchestration, quality gates, TDD, and PR shepherding for Codex",
+    "longDescription": "Use metaswarm to plan, decompose, execute, review, and shepherd development work with specialized agent roles, BEADS-backed tracking, strict quality gates, and cross-platform support for Claude Code, Gemini CLI, and Codex CLI.",
+    "developerName": "David Sifry",
+    "category": "Coding",
+    "capabilities": [
+      "Interactive",
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/dsifry/metaswarm",
+    "privacyPolicyURL": "https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement",
+    "termsOfServiceURL": "https://docs.github.com/en/site-policy/github-terms/github-terms-of-service",
+    "defaultPrompt": [
+      "Use metaswarm to set up this project.",
+      "Use metaswarm to start tracked work on this task.",
+      "Use metaswarm to shepherd this PR until it is ready to merge."
+    ],
+    "brandColor": "#0F766E",
+    "screenshots": []
+  }
+}

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,16 +1,32 @@
 # metaswarm for Codex CLI
 
-Install metaswarm's 13 orchestration skills for [Codex CLI](https://github.com/openai/codex).
+Install metaswarm's orchestration skills as a [Codex CLI](https://github.com/openai/codex) plugin.
 
 ## Install
 
-### Quick install
+### Plugin marketplace install
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/dsifry/metaswarm/main/.codex/install.sh | bash
+codex plugin marketplace add dsifry/metaswarm-marketplace
+codex
+# In Codex, open /plugins, select the metaswarm marketplace, and install metaswarm.
 ```
 
-### Manual install
+### Local checkout install
+
+From a metaswarm checkout:
+
+```bash
+codex plugin marketplace add /path/to/metaswarm
+codex
+# In Codex, open /plugins, select "metaswarm", and install metaswarm.
+```
+
+The repo-local marketplace points at the public metaswarm repository root. For testing an unmerged branch, use a temporary marketplace whose plugin source URL is a `file://` URL or a pushed branch ref.
+
+### Legacy manual install
+
+Use this only if your Codex build does not support plugins:
 
 ```bash
 git clone https://github.com/dsifry/metaswarm.git ~/.codex/metaswarm
@@ -58,25 +74,25 @@ Codex uses the `name` field from each skill's `SKILL.md` frontmatter — not the
 | `$migrate` | `migrate` | Migrate from npm installation |
 | `$visual-review` | `visual-review` | Playwright screenshot capture |
 
-## Limitations
+## Execution Model
 
-Codex CLI does not have a `Task()` equivalent for spawning subagents. This means:
+Codex supports skills and subagents, but the exact orchestration surface is not identical to Claude Code. metaswarm skills should follow `skills/start/references/codex-tools.md` for tool mapping.
 
-- **Design review** runs sequentially (each reviewer perspective one at a time) instead of in parallel
-- **Adversarial review** uses rubrics as structured checklists rather than fresh isolated reviewers
-- **Background tasks** are not available; all work runs in the current session
+- Use `$setup`, `$start`, `$status`, and `$pr-shepherd` in Codex.
+- Do not use Claude slash-command shims in Codex.
+- Plugin hooks are optional in Codex and require the `plugin_hooks` feature. Core metaswarm workflows do not depend on hooks.
 
-The quality gates and rubric criteria are identical — the same review standards apply regardless of platform. The difference is execution mode (sequential vs parallel), not review thoroughness.
+The quality gates and rubric criteria are identical across platforms. The difference is invocation and tool mapping, not review standards.
 
 ## Updating
 
-```bash
-cd ~/.codex/metaswarm && git pull
-```
-
-Or re-run the install script — it detects existing installations and updates in-place.
+Use Codex's plugin marketplace update flow for plugin installs. For legacy manual installs, re-run `.codex/install.sh` or pull the clone under `~/.codex/metaswarm`.
 
 ## Uninstall
+
+Use Codex's `/plugins` UI to uninstall plugin installs.
+
+For legacy manual installs:
 
 ```bash
 # Remove skill symlinks

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,10 +27,12 @@ Then in Gemini CLI:
 /metaswarm:setup
 ```
 
-## Codex CLI (Skills)
+## Codex CLI (Plugin Marketplace)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/dsifry/metaswarm/main/.codex/install.sh | bash
+codex plugin marketplace add dsifry/metaswarm-marketplace
+codex
+# Then open /plugins, select the metaswarm marketplace, and install metaswarm.
 ```
 
 Then in Codex CLI:
@@ -38,6 +40,8 @@ Then in Codex CLI:
 ```text
 $setup
 ```
+
+Legacy fallback: if plugin marketplaces are unavailable in your Codex build, use `.codex/install.sh` to clone metaswarm and symlink the skills manually.
 
 ## Cross-Platform Installer
 
@@ -65,7 +69,7 @@ npx metaswarm setup
 
 | Feature | Claude Code | Gemini CLI | Codex CLI |
 |---|---|---|---|
-| Install method | Plugin marketplace | `gemini extensions install` | Clone + symlink |
+| Install method | Plugin marketplace | `gemini extensions install` | Plugin marketplace |
 | Commands | `/start-task` | `/metaswarm:start-task` | `$start` |
 | Instruction file | `CLAUDE.md` | `GEMINI.md` | `AGENTS.md` |
 | Parallel agents | Full (`Task()`) | Experimental | Sequential only |
@@ -83,11 +87,12 @@ npx metaswarm setup
    brew install gh   # macOS
    gh auth login
    ```
-4. **Superpowers Plugin** (optional, Claude Code only) — See [External Dependencies](#external-dependencies)
+4. **Superpowers Plugin** (optional, Claude Code and Codex) — See [External Dependencies](#external-dependencies)
+5. **GTG CLI** (`gtg`) — For the fastest PR readiness checks in `pr-shepherd`
 
 ## External Dependencies
 
-metaswarm's skills reference these external skills from the [superpowers](https://github.com/obra/superpowers) Claude Code plugin:
+metaswarm's skills reference external skills from the [superpowers](https://github.com/obra/superpowers) plugin. Superpowers is available for Claude Code and as a Codex plugin.
 
 | Skill | Used By | Purpose |
 |---|---|---|
@@ -97,13 +102,17 @@ metaswarm's skills reference these external skills from the [superpowers](https:
 | `superpowers:writing-plans` | Design Review Gate, Brainstorming Extension | Detailed implementation plan generation |
 | `superpowers:using-git-worktrees` | Design Review Gate | Isolated workspace creation for parallel dev |
 
-**Install superpowers** (follow their README for current instructions):
+**Install superpowers** (follow their README and marketplace docs for current instructions):
 ```bash
 # See: https://github.com/obra/superpowers
 claude plugin add obra/superpowers
+
+# Codex: install from the claude-plugins-official marketplace in /plugins
 ```
 
 **Without superpowers**: metaswarm still works — the core orchestration (agents, BEADS, review gates, rubrics) is self-contained. The superpowers references are in skill trigger chains and can be removed or replaced with your own equivalents.
+
+**BEADS and GTG**: metaswarm does not auto-install runtime CLIs. Install `bd` for BEADS issue tracking and knowledge priming, and install `gtg` for consolidated PR readiness checks. The standalone Beads plugin is optional; metaswarm detects it and defers priming when present.
 
 ## Optional: External AI Tools
 
@@ -184,7 +193,7 @@ If you skip the manual migration, the session-start hook will detect the old npm
 /status
 ```
 
-This runs 9 diagnostic checks: plugin version, project setup, command shims, legacy install detection, BEADS plugin, bd CLI, external tools, coverage thresholds, and Node.js.
+This runs platform-aware diagnostic checks: plugin version, project setup, platform install state, command shims where applicable, legacy install detection, BEADS plugin, bd CLI, gtg CLI, external tools, coverage thresholds, and Node.js.
 
 ## npm Package (Cross-Platform Installer)
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Then run `/metaswarm:setup` in your project.
 ### Codex CLI
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/dsifry/metaswarm/main/.codex/install.sh | bash
+codex plugin marketplace add dsifry/metaswarm-marketplace
+codex
+# Open /plugins, select the metaswarm marketplace, and install metaswarm.
 ```
 
 Then run `$setup` in your project.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ This means the knowledge base can grow to hundreds or thousands of entries witho
 |---|---|---|
 | [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Plugin marketplace | `/start-task`, `/setup`, etc. |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Extension (`gemini extensions install`) | `/metaswarm:start-task`, etc. |
-| [Codex CLI](https://github.com/openai/codex) | Skills (`curl \| bash`) | `$start`, `$setup`, etc. |
+| [Codex CLI](https://github.com/openai/codex) | Plugin marketplace | `$start`, `$setup`, etc. |
 
 ## Requirements
 

--- a/commands/metaswarm/status.toml
+++ b/commands/metaswarm/status.toml
@@ -3,5 +3,5 @@ prompt = """Invoke the metaswarm status skill. The user wants to check their ins
 
 Arguments provided by the user: {{args}}
 
-Run all 9 diagnostic checks: plugin version, project setup, command shims, legacy install, BEADS, bd CLI, external tools, coverage thresholds, Node.js.
+Run the platform-aware diagnostic checks: plugin version, project setup, platform install state, command shims where applicable, legacy install, BEADS, bd CLI, gtg CLI, external tools, coverage thresholds, Node.js.
 """

--- a/commands/metaswarm/status.toml
+++ b/commands/metaswarm/status.toml
@@ -1,7 +1,5 @@
 description = "Run diagnostic checks on your metaswarm installation"
-prompt = """$status
-
-The user wants to check their installation status.
+prompt = """Invoke the metaswarm status skill. The user wants to check their installation status.
 
 Arguments provided by the user: {{args}}
 

--- a/commands/metaswarm/status.toml
+++ b/commands/metaswarm/status.toml
@@ -1,5 +1,7 @@
 description = "Run diagnostic checks on your metaswarm installation"
-prompt = """Invoke the metaswarm status skill. The user wants to check their installation status.
+prompt = """$status
+
+The user wants to check their installation status.
 
 Arguments provided by the user: {{args}}
 

--- a/docs/README.codex.md
+++ b/docs/README.codex.md
@@ -1,1 +1,42 @@
-# Codex CLI Integration (Future)
+# Codex CLI Integration
+
+metaswarm supports Codex as a first-class plugin.
+
+## Install from Marketplace
+
+```bash
+codex plugin marketplace add dsifry/metaswarm-marketplace
+codex
+```
+
+Then open `/plugins`, select the metaswarm marketplace, and install metaswarm.
+
+## Local Development Install
+
+From a metaswarm checkout:
+
+```bash
+codex plugin marketplace add /path/to/metaswarm
+codex
+```
+
+Then open `/plugins`, select `metaswarm`, and install metaswarm.
+
+The repo-local marketplace points at the public metaswarm repository root. For testing an unmerged branch, use a temporary marketplace whose plugin source URL is a `file://` URL or a pushed branch ref.
+
+## Invoke Skills
+
+Codex invokes metaswarm by skill name:
+
+| Command | Purpose |
+|---|---|
+| `$setup` | Configure the current project |
+| `$start` | Begin tracked work |
+| `$status` | Diagnose installation and project state |
+| `$pr-shepherd` | Monitor a PR through readiness |
+
+Claude slash-command shims are not used in Codex.
+
+## Hooks
+
+Codex plugin hooks are optional and require the `plugin_hooks` feature. Core metaswarm workflows are designed to work without hook context.

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -9,29 +9,42 @@ set -euo pipefail
 # Works with Codex ($PLUGIN_ROOT), Claude Code ($CLAUDE_PLUGIN_ROOT),
 # Gemini CLI ($extensionPath), or direct invocation (derive from script location)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CODEX_PLUGIN_ROOT="${PLUGIN_ROOT:-}"
 PLUGIN_ROOT="${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${extensionPath:-$(cd "$SCRIPT_DIR/.." && pwd)}}}"
+METASWARM_PLATFORM="${METASWARM_PLATFORM:-}"
+if [ -z "$METASWARM_PLATFORM" ]; then
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    METASWARM_PLATFORM="claude"
+  elif [ -n "${extensionPath:-}" ]; then
+    METASWARM_PLATFORM="gemini"
+  elif [ -n "$CODEX_PLUGIN_ROOT" ] || [ -n "${CODEX_HOME:-}" ]; then
+    METASWARM_PLATFORM="codex"
+  else
+    METASWARM_PLATFORM="claude"
+  fi
+fi
 
 # --- Phase 1: BEADS dedup check ---
 # If standalone BEADS plugin is installed, skip knowledge priming (let BEADS handle it)
 beads_standalone=false
 beads_plugin_caches=("${HOME}/.claude/plugins/cache" "${CODEX_HOME:-${HOME}/.codex}/plugins/cache")
 for beads_plugin_cache in "${beads_plugin_caches[@]}"; do
-if [ -d "$beads_plugin_cache" ]; then
-  # Look for a BEADS plugin with name "beads" in plugin.json
-  while IFS= read -r -d '' pjson; do
-    pname=""
-    if command -v jq >/dev/null 2>&1; then
-      pname=$(jq -r '.name // empty' "$pjson" 2>/dev/null || true)
-    elif command -v node >/dev/null 2>&1; then
-      pname=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')).name||'')}catch{console.log('')}" "$pjson" 2>/dev/null || true)
-    fi
-    # Neither jq nor node available — skip dedup check (safe default: allow both to prime)
-    if [ "$pname" = "beads" ]; then
-      beads_standalone=true
-      break
-    fi
-  done < <(find "$beads_plugin_cache" \( -path "*/.claude-plugin/plugin.json" -o -path "*/.codex-plugin/plugin.json" \) -print0 2>/dev/null || true)
-fi
+  if [ -d "$beads_plugin_cache" ]; then
+    # Look for a BEADS plugin with name "beads" in plugin.json
+    while IFS= read -r -d '' pjson; do
+      pname=""
+      if command -v jq >/dev/null 2>&1; then
+        pname=$(jq -r '.name // empty' "$pjson" 2>/dev/null || true)
+      elif command -v node >/dev/null 2>&1; then
+        pname=$(node -e "try{console.log(JSON.parse(require('fs').readFileSync(process.argv[1],'utf-8')).name||'')}catch{console.log('')}" "$pjson" 2>/dev/null || true)
+      fi
+      # Neither jq nor node available — skip dedup check (safe default: allow both to prime)
+      if [ "$pname" = "beads" ]; then
+        beads_standalone=true
+        break
+      fi
+    done < <(find "$beads_plugin_cache" \( -path "*/.claude-plugin/plugin.json" -o -path "*/.codex-plugin/plugin.json" \) -print0 2>/dev/null || true)
+  fi
   [ "$beads_standalone" = true ] && break
 done
 
@@ -54,14 +67,20 @@ if [ "$new_project" = false ] && [ "$legacy_install" = false ]; then
   setup_script="${PLUGIN_ROOT}/lib/setup-mandatory-files.sh"
   needs_heal=false
 
-  # Check the 3 mandatory files
-  if ! grep -q "metaswarm" CLAUDE.md 2>/dev/null; then
+  case "$METASWARM_PLATFORM" in
+    codex) instruction_file="AGENTS.md" ;;
+    gemini) instruction_file="GEMINI.md" ;;
+    *) instruction_file="CLAUDE.md" ;;
+  esac
+
+  if ! grep -q "metaswarm" "$instruction_file" 2>/dev/null; then
     needs_heal=true
   fi
   if [ ! -f ".coverage-thresholds.json" ]; then
     needs_heal=true
   fi
-  if [ ! -f ".claude/commands/start-task.md" ] || ! grep -q "metaswarm" ".claude/commands/start-task.md" 2>/dev/null; then
+  if { [ "$METASWARM_PLATFORM" = "claude" ] || [ "$METASWARM_PLATFORM" = "all" ]; } \
+    && { [ ! -f ".claude/commands/start-task.md" ] || ! grep -q "metaswarm" ".claude/commands/start-task.md" 2>/dev/null; }; then
     needs_heal=true
   fi
 
@@ -84,7 +103,7 @@ if [ "$new_project" = false ] && [ "$legacy_install" = false ]; then
     [ -z "$cov_cmd" ] && cov_cmd="pytest --cov --cov-fail-under=${cov_threshold}"
 
     # Run the setup script silently
-    bash "$setup_script" "$(pwd)" "$cov_threshold" "$cov_cmd" >/dev/null 2>&1 || true
+    bash "$setup_script" "$(pwd)" "$cov_threshold" "$cov_cmd" --platform "$METASWARM_PLATFORM" >/dev/null 2>&1 || true
   fi
 fi
 
@@ -92,11 +111,11 @@ fi
 context_parts=()
 
 if [ "$new_project" = true ]; then
-  context_parts+=("Metaswarm is installed but this project hasn't been set up yet. Run \`/metaswarm:setup\` to configure it, or \`/metaswarm:start-task\` to begin working.")
+  context_parts+=("Metaswarm is installed but this project hasn't been set up yet. Run \`\$setup\` to configure it, or \`\$start\` to begin working.")
 fi
 
 if [ "$legacy_install" = true ]; then
-  context_parts+=("This project has metaswarm installed via the old npm method. The marketplace plugin is now active and provides all the same skills and commands. Run \`/metaswarm:migrate\` to clean up the redundant copies — this is a safe, reversible operation that only removes duplicate framework files (your project files are never touched).")
+  context_parts+=("This project has metaswarm installed via the old npm method. The marketplace plugin is now active and provides all the same skills and commands. Run \`\$migrate\` to clean up the redundant copies — this is a safe, reversible operation that only removes duplicate framework files (your project files are never touched).")
 fi
 
 # Knowledge priming (only if project is set up and BEADS isn't separately priming)

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -110,12 +110,28 @@ fi
 # --- Phase 4: Build context message ---
 context_parts=()
 
+setup_cmd='$setup'
+start_cmd='$start'
+migrate_cmd='$migrate'
+case "$METASWARM_PLATFORM" in
+  claude)
+    setup_cmd='/setup'
+    start_cmd='/start-task'
+    migrate_cmd='/migrate'
+    ;;
+  gemini)
+    setup_cmd='/metaswarm:setup'
+    start_cmd='/metaswarm:start-task'
+    migrate_cmd='/metaswarm:migrate'
+    ;;
+esac
+
 if [ "$new_project" = true ]; then
-  context_parts+=("Metaswarm is installed but this project hasn't been set up yet. Run \`\$setup\` to configure it, or \`\$start\` to begin working.")
+  context_parts+=("Metaswarm is installed but this project hasn't been set up yet. Run \`${setup_cmd}\` to configure it, or \`${start_cmd}\` to begin working.")
 fi
 
 if [ "$legacy_install" = true ]; then
-  context_parts+=("This project has metaswarm installed via the old npm method. The marketplace plugin is now active and provides all the same skills and commands. Run \`\$migrate\` to clean up the redundant copies — this is a safe, reversible operation that only removes duplicate framework files (your project files are never touched).")
+  context_parts+=("This project has metaswarm installed via the old npm method. The marketplace plugin is now active and provides all the same skills and commands. Run \`${migrate_cmd}\` to clean up the redundant copies — this is a safe, reversible operation that only removes duplicate framework files (your project files are never touched).")
 fi
 
 # Knowledge priming (only if project is set up and BEADS isn't separately priming)

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -6,15 +6,16 @@
 set -euo pipefail
 
 # --- Phase 0: Self-locate plugin root ---
-# Works with Claude Code ($CLAUDE_PLUGIN_ROOT), Gemini CLI ($extensionPath),
-# or direct invocation (derive from script location)
+# Works with Codex ($PLUGIN_ROOT), Claude Code ($CLAUDE_PLUGIN_ROOT),
+# Gemini CLI ($extensionPath), or direct invocation (derive from script location)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-${extensionPath:-$(cd "$SCRIPT_DIR/.." && pwd)}}"
+PLUGIN_ROOT="${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${extensionPath:-$(cd "$SCRIPT_DIR/.." && pwd)}}}"
 
 # --- Phase 1: BEADS dedup check ---
 # If standalone BEADS plugin is installed, skip knowledge priming (let BEADS handle it)
 beads_standalone=false
-beads_plugin_cache="${HOME}/.claude/plugins/cache"
+beads_plugin_caches=("${HOME}/.claude/plugins/cache" "${CODEX_HOME:-${HOME}/.codex}/plugins/cache")
+for beads_plugin_cache in "${beads_plugin_caches[@]}"; do
 if [ -d "$beads_plugin_cache" ]; then
   # Look for a BEADS plugin with name "beads" in plugin.json
   while IFS= read -r -d '' pjson; do
@@ -29,8 +30,10 @@ if [ -d "$beads_plugin_cache" ]; then
       beads_standalone=true
       break
     fi
-  done < <(find "$beads_plugin_cache" -path "*/.claude-plugin/plugin.json" -print0 2>/dev/null || true)
+  done < <(find "$beads_plugin_cache" \( -path "*/.claude-plugin/plugin.json" -o -path "*/.codex-plugin/plugin.json" \) -print0 2>/dev/null || true)
 fi
+  [ "$beads_standalone" = true ] && break
+done
 
 # --- Phase 2: New project detection ---
 new_project=false

--- a/lib/platform-detect.js
+++ b/lib/platform-detect.js
@@ -51,17 +51,17 @@ function detectClaude() {
 
 function detectCodex() {
   const installed = commandExists('codex');
-  const installDir = path.join(process.env.CODEX_HOME || path.join(os.homedir(), '.codex'), 'metaswarm');
-  const skillsDir = path.join(os.homedir(), '.agents', 'skills');
+  const configDir = process.env.CODEX_HOME || path.join(os.homedir(), '.codex');
+  const pluginCacheDir = path.join(configDir, 'plugins', 'cache');
 
   return {
     installed,
     name: 'Codex CLI',
     command: 'codex',
-    installDir,
-    skillsDir,
-    installMethod: 'clone+symlink',
-    installCommand: 'bash .codex/install.sh',
+    configDir,
+    pluginCacheDir,
+    installMethod: 'plugin',
+    installCommand: 'codex plugin marketplace add dsifry/metaswarm-marketplace',
     setupCommand: '$setup',
     instructionFile: 'AGENTS.md',
   };

--- a/lib/setup-mandatory-files.sh
+++ b/lib/setup-mandatory-files.sh
@@ -127,42 +127,46 @@ else
   fi
 fi
 
-# --- File 3: 6 command shims in .claude/commands/ ---
+# --- File 3: Claude command shims (Claude/all only) ---
+if [ "$PLATFORM" = "claude" ] || [ "$PLATFORM" = "all" ]; then
 commands_dir="$PROJECT_DIR/.claude/commands"
 mkdir -p "$commands_dir"
 
-shims=(
-  "start-task:start-task"
-  "start:start-task"
-  "prime:prime"
-  "review-design:review-design"
-  "self-reflect:self-reflect"
-  "pr-shepherd:pr-shepherd"
-  "brainstorm:brainstorm"
-)
+  shims=(
+    "start-task:start-task"
+    "start:start-task"
+    "prime:prime"
+    "review-design:review-design"
+    "self-reflect:self-reflect"
+    "pr-shepherd:pr-shepherd"
+    "brainstorm:brainstorm"
+  )
 
-for entry in "${shims[@]}"; do
-  file_name="${entry%%:*}"
-  command_name="${entry##*:}"
-  shim_path="$commands_dir/${file_name}.md"
-  shim_content="<!-- Created by metaswarm setup. Routes to the metaswarm plugin. Safe to delete if you uninstall metaswarm. -->
+  for entry in "${shims[@]}"; do
+    file_name="${entry%%:*}"
+    command_name="${entry##*:}"
+    shim_path="$commands_dir/${file_name}.md"
+    shim_content="<!-- Created by metaswarm setup. Routes to the metaswarm plugin. Safe to delete if you uninstall metaswarm. -->
 
 Invoke the \`/metaswarm:${command_name}\` skill to handle this request. Pass along any arguments the user provided."
 
-  if [ -f "$shim_path" ]; then
-    existing=$(cat "$shim_path")
-    if [ "$existing" = "$shim_content" ]; then
-      skipped+=(".claude/commands/${file_name}.md (already correct)")
+    if [ -f "$shim_path" ]; then
+      existing=$(cat "$shim_path")
+      if [ "$existing" = "$shim_content" ]; then
+        skipped+=(".claude/commands/${file_name}.md (already correct)")
+      else
+        # Overwrite — existing content is from a different plugin/project
+        printf '%s' "$shim_content" > "$shim_path"
+        created+=(".claude/commands/${file_name}.md (overwritten with metaswarm routing)")
+      fi
     else
-      # Overwrite — existing content is from a different plugin/project
       printf '%s' "$shim_content" > "$shim_path"
-      created+=(".claude/commands/${file_name}.md (overwritten with metaswarm routing)")
+      created+=(".claude/commands/${file_name}.md")
     fi
-  else
-    printf '%s' "$shim_content" > "$shim_path"
-    created+=(".claude/commands/${file_name}.md")
-  fi
-done
+  done
+else
+  skipped+=(".claude/commands shims (not needed for ${PLATFORM})")
+fi
 
 # --- Output results as JSON ---
 echo "{"

--- a/lib/setup-mandatory-files.sh
+++ b/lib/setup-mandatory-files.sh
@@ -129,8 +129,8 @@ fi
 
 # --- File 3: Claude command shims (Claude/all only) ---
 if [ "$PLATFORM" = "claude" ] || [ "$PLATFORM" = "all" ]; then
-commands_dir="$PROJECT_DIR/.claude/commands"
-mkdir -p "$commands_dir"
+  commands_dir="$PROJECT_DIR/.claude/commands"
+  mkdir -p "$commands_dir"
 
   shims=(
     "start-task:start-task"

--- a/lib/sync-resources.js
+++ b/lib/sync-resources.js
@@ -121,7 +121,7 @@ const TOML_COMMAND_MAP = {
   },
   'status': {
     description: 'Run diagnostic checks on your metaswarm installation',
-    prompt: '$status\n\nThe user wants to check their installation status.\n\nArguments provided by the user: {{args}}\n\nRun the platform-aware diagnostic checks: plugin version, project setup, platform install state, command shims where applicable, legacy install, BEADS, bd CLI, gtg CLI, external tools, coverage thresholds, Node.js.'
+    prompt: 'Invoke the metaswarm status skill. The user wants to check their installation status.\n\nArguments provided by the user: {{args}}\n\nRun the platform-aware diagnostic checks: plugin version, project setup, platform install state, command shims where applicable, legacy install, BEADS, bd CLI, gtg CLI, external tools, coverage thresholds, Node.js.'
   },
   'handle-pr-comments': {
     description: 'Handle PR review comments with the full resolution workflow',

--- a/lib/sync-resources.js
+++ b/lib/sync-resources.js
@@ -121,7 +121,7 @@ const TOML_COMMAND_MAP = {
   },
   'status': {
     description: 'Run diagnostic checks on your metaswarm installation',
-    prompt: 'Invoke the metaswarm status skill. The user wants to check their installation status.\n\nArguments provided by the user: {{args}}\n\nRun the platform-aware diagnostic checks: plugin version, project setup, platform install state, command shims where applicable, legacy install, BEADS, bd CLI, gtg CLI, external tools, coverage thresholds, Node.js.'
+    prompt: '$status\n\nThe user wants to check their installation status.\n\nArguments provided by the user: {{args}}\n\nRun the platform-aware diagnostic checks: plugin version, project setup, platform install state, command shims where applicable, legacy install, BEADS, bd CLI, gtg CLI, external tools, coverage thresholds, Node.js.'
   },
   'handle-pr-comments': {
     description: 'Handle PR review comments with the full resolution workflow',
@@ -217,7 +217,10 @@ function validateManifests() {
     issues++;
   }
 
-  if (fs.existsSync(codexPluginPath)) {
+  if (!fs.existsSync(codexPluginPath)) {
+    console.error('MISSING: .codex-plugin/plugin.json');
+    issues++;
+  } else {
     try {
       const codexPlugin = JSON.parse(fs.readFileSync(codexPluginPath, 'utf-8'));
       if (codexPlugin.name !== 'metaswarm') {
@@ -250,12 +253,19 @@ function validateManifests() {
           console.error('INVALID: metaswarm Codex marketplace source must point at the metaswarm repository root URL');
           issues++;
         }
-        if (!entry.policy || !entry.policy.installation || !entry.policy.authentication) {
-          console.error('INVALID: metaswarm Codex marketplace entry must include policy.installation and policy.authentication');
+        const allowedInstallation = new Set(['NOT_AVAILABLE', 'AVAILABLE', 'INSTALLED_BY_DEFAULT']);
+        const allowedAuthentication = new Set(['ON_INSTALL', 'ON_USE']);
+        const allowedCategories = new Set(['Coding', 'Productivity', 'Engineering']);
+        if (!entry.policy || !allowedInstallation.has(entry.policy.installation)) {
+          console.error(`INVALID: metaswarm Codex marketplace policy.installation must be one of ${[...allowedInstallation].join(', ')}`);
           issues++;
         }
-        if (!entry.category) {
-          console.error('INVALID: metaswarm Codex marketplace entry must include category');
+        if (!entry.policy || !allowedAuthentication.has(entry.policy.authentication)) {
+          console.error(`INVALID: metaswarm Codex marketplace policy.authentication must be one of ${[...allowedAuthentication].join(', ')}`);
+          issues++;
+        }
+        if (typeof entry.category !== 'string' || !allowedCategories.has(entry.category)) {
+          console.error(`INVALID: metaswarm Codex marketplace category must be one of ${[...allowedCategories].join(', ')}`);
           issues++;
         }
       }

--- a/lib/sync-resources.js
+++ b/lib/sync-resources.js
@@ -121,7 +121,7 @@ const TOML_COMMAND_MAP = {
   },
   'status': {
     description: 'Run diagnostic checks on your metaswarm installation',
-    prompt: 'Invoke the metaswarm status skill. The user wants to check their installation status.\n\nArguments provided by the user: {{args}}\n\nRun all 9 diagnostic checks: plugin version, project setup, command shims, legacy install, BEADS, bd CLI, external tools, coverage thresholds, Node.js.'
+    prompt: 'Invoke the metaswarm status skill. The user wants to check their installation status.\n\nArguments provided by the user: {{args}}\n\nRun the platform-aware diagnostic checks: plugin version, project setup, platform install state, command shims where applicable, legacy install, BEADS, bd CLI, gtg CLI, external tools, coverage thresholds, Node.js.'
   },
   'handle-pr-comments': {
     description: 'Handle PR review comments with the full resolution workflow',
@@ -185,13 +185,16 @@ function checkTomlCommands() {
 function validateManifests() {
   let issues = 0;
   const pkgPath = path.join(ROOT, 'package.json');
-  const pluginPath = path.join(ROOT, '.claude-plugin', 'plugin.json');
+  const claudePluginPath = path.join(ROOT, '.claude-plugin', 'plugin.json');
+  const codexPluginPath = path.join(ROOT, '.codex-plugin', 'plugin.json');
   const geminiPath = path.join(ROOT, 'gemini-extension.json');
+  const codexMarketplacePath = path.join(ROOT, '.agents', 'plugins', 'marketplace.json');
 
   const versions = {};
   const manifests = [
     ['package.json', pkgPath],
-    ['plugin.json', pluginPath],
+    ['.claude-plugin/plugin.json', claudePluginPath],
+    ['.codex-plugin/plugin.json', codexPluginPath],
     ['gemini-extension.json', geminiPath],
   ];
 
@@ -212,6 +215,54 @@ function validateManifests() {
       console.error(`  ${file}: ${ver}`);
     }
     issues++;
+  }
+
+  if (fs.existsSync(codexPluginPath)) {
+    try {
+      const codexPlugin = JSON.parse(fs.readFileSync(codexPluginPath, 'utf-8'));
+      if (codexPlugin.name !== 'metaswarm') {
+        console.error(`INVALID: .codex-plugin/plugin.json name must be "metaswarm" (found ${JSON.stringify(codexPlugin.name)})`);
+        issues++;
+      }
+      if (codexPlugin.skills !== './skills/') {
+        console.error(`INVALID: .codex-plugin/plugin.json skills must be "./skills/" (found ${JSON.stringify(codexPlugin.skills)})`);
+        issues++;
+      }
+    } catch (e) {
+      // Already reported by manifest parsing above; keep this guard local.
+    }
+  }
+
+  if (!fs.existsSync(codexMarketplacePath)) {
+    console.error('MISSING: .agents/plugins/marketplace.json');
+    issues++;
+  } else {
+    try {
+      const marketplace = JSON.parse(fs.readFileSync(codexMarketplacePath, 'utf-8'));
+      const entry = Array.isArray(marketplace.plugins)
+        ? marketplace.plugins.find(plugin => plugin && plugin.name === 'metaswarm')
+        : null;
+      if (!entry) {
+        console.error('INVALID: .agents/plugins/marketplace.json must include a metaswarm plugin entry');
+        issues++;
+      } else {
+        if (!entry.source || entry.source.source !== 'url' || entry.source.url !== 'https://github.com/dsifry/metaswarm.git') {
+          console.error('INVALID: metaswarm Codex marketplace source must point at the metaswarm repository root URL');
+          issues++;
+        }
+        if (!entry.policy || !entry.policy.installation || !entry.policy.authentication) {
+          console.error('INVALID: metaswarm Codex marketplace entry must include policy.installation and policy.authentication');
+          issues++;
+        }
+        if (!entry.category) {
+          console.error('INVALID: metaswarm Codex marketplace entry must include category');
+          issues++;
+        }
+      }
+    } catch (e) {
+      console.error(`MALFORMED: .agents/plugins/marketplace.json — ${e.message}`);
+      issues++;
+    }
   }
 
   // Check template files exist

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -5,15 +5,25 @@ description: Interactive project setup — detects your project, configures meta
 
 # Setup
 
-Interactive, Claude-guided setup for metaswarm. Detects your stack, asks targeted questions, writes project-local files, and creates command shims. Replaces both `npx metaswarm init` and the old `/metaswarm-setup` command.
+Interactive setup for metaswarm. Detects your stack, asks targeted questions, writes project-local files, and creates platform-appropriate instruction files and command shims. Replaces both `npx metaswarm init` and the old `/metaswarm-setup` command.
 
 <CRITICAL-REQUIREMENTS>
-Setup MUST produce these 3 mandatory outputs. A shell script handles them automatically — you MUST run it.
+Setup MUST produce the mandatory outputs for the active platform. A shell script handles them automatically — you MUST run it.
 
 After Phase 2 (user questions), determine the correct coverage command from the detection results, then run this Bash command:
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/lib/setup-mandatory-files.sh" "$(pwd)" <threshold> "<coverage-command>"
+PLUGIN_ROOT="${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${extensionPath:-}}}"
+if [ -z "$PLUGIN_ROOT" ]; then
+  setup_script="$(find "${CODEX_HOME:-$HOME/.codex}/plugins/cache" -path '*/metaswarm/*/lib/setup-mandatory-files.sh' -print -quit 2>/dev/null)"
+  if [ -n "$setup_script" ]; then
+    PLUGIN_ROOT="$(cd "$(dirname "$setup_script")/.." && pwd)"
+  fi
+fi
+if [ -z "$PLUGIN_ROOT" ] && [ -f "$(pwd)/lib/setup-mandatory-files.sh" ]; then
+  PLUGIN_ROOT="$(pwd)"
+fi
+bash "${PLUGIN_ROOT}/lib/setup-mandatory-files.sh" "$(pwd)" <threshold> "<coverage-command>" --platform <platform>
 ```
 
 Where:
@@ -24,11 +34,16 @@ Where:
   - jest/npm → `"npx jest --coverage"`
   - go → `"go test -coverprofile=coverage.out ./..."`
   - cargo → `"cargo tarpaulin --fail-under <threshold>"`
+- `<platform>` is `codex`, `claude`, `gemini`, or `all`. Prefer:
+  - `codex` when running in Codex (`PLUGIN_ROOT` or `CODEX_HOME` is present, or the user invoked `$setup`)
+  - `claude` when running in Claude Code (`CLAUDE_PLUGIN_ROOT` is present, or the user invoked `/setup`)
+  - `gemini` when running in Gemini (`extensionPath` is present, or the user invoked `/metaswarm:setup`)
+  - `all` only when the user explicitly asks to configure every supported CLI
 
 The script handles:
-1. **CLAUDE.md** — appends metaswarm section (or writes new), skips if already present
+1. **Instruction file** — `AGENTS.md` for Codex, `CLAUDE.md` for Claude, `GEMINI.md` for Gemini; appends metaswarm section (or writes new), skips if already present
 2. **`.coverage-thresholds.json`** — writes at project root with correct thresholds and command
-3. **6 shims in `.claude/commands/`** — writes `start-task.md`, `prime.md`, `review-design.md`, `self-reflect.md`, `pr-shepherd.md`, `brainstorm.md`
+3. **Claude command shims** — for Claude/all only, writes `.claude/commands/start-task.md`, `prime.md`, `review-design.md`, `self-reflect.md`, `pr-shepherd.md`, `brainstorm.md`
 
 The script outputs JSON with what was created/skipped/errored. Check that `"status": "ok"`.
 
@@ -212,26 +227,36 @@ Use AskUserQuestion to ask ONLY questions relevant based on detection. 3-5 quest
 This is the FIRST thing to do after Phase 2. Determine the coverage command, then run:
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/lib/setup-mandatory-files.sh" "$(pwd)" <threshold> "<coverage-command>"
+PLUGIN_ROOT="${PLUGIN_ROOT:-${CLAUDE_PLUGIN_ROOT:-${extensionPath:-}}}"
+if [ -z "$PLUGIN_ROOT" ]; then
+  setup_script="$(find "${CODEX_HOME:-$HOME/.codex}/plugins/cache" -path '*/metaswarm/*/lib/setup-mandatory-files.sh' -print -quit 2>/dev/null)"
+  if [ -n "$setup_script" ]; then
+    PLUGIN_ROOT="$(cd "$(dirname "$setup_script")/.." && pwd)"
+  fi
+fi
+if [ -z "$PLUGIN_ROOT" ] && [ -f "$(pwd)/lib/setup-mandatory-files.sh" ]; then
+  PLUGIN_ROOT="$(pwd)"
+fi
+bash "${PLUGIN_ROOT}/lib/setup-mandatory-files.sh" "$(pwd)" <threshold> "<coverage-command>" --platform <platform>
 ```
 
-Example for Python with pytest at 100%:
+Example for Codex with Python/pytest at 100%:
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/lib/setup-mandatory-files.sh" "$(pwd)" 100 "pytest --cov --cov-fail-under=100"
+bash "${PLUGIN_ROOT}/lib/setup-mandatory-files.sh" "$(pwd)" 100 "pytest --cov --cov-fail-under=100" --platform codex
 ```
 
 Check the JSON output. If `"status": "ok"`, the 3 mandatory files are done. Report to the user what was created.
 
 If the script fails or is not found, write the files manually (see CRITICAL-REQUIREMENTS above for what they are).
 
-### Step 2: Customize CLAUDE.md TODO sections
+### Step 2: Customize instruction-file TODO sections
 
-If CLAUDE.md was newly written (not appended), use Edit to replace the TODO placeholders:
+If the instruction file was newly written (not appended), use Edit to replace the TODO placeholders:
 - Replace `npm test` / `npm run test:coverage` with the detected test/coverage commands
 - Replace `TypeScript strict mode` / `ESLint + Prettier` with the detected language tools
 - Remove the `<!-- TODO: ... -->` comment lines
 
-If CLAUDE.md was appended to (existing file), this step is not needed.
+If the instruction file was appended to (existing file), this step is not needed.
 
 ---
 
@@ -379,17 +404,20 @@ Setup complete! Here's what was configured:
   Visual review:   {Enabled/Disabled}
 
 Mandatory files:
-  ✔ CLAUDE.md          — {written new / appended metaswarm section / already had it}
+  ✔ {instruction file} — {written new / appended metaswarm section / already had it}
   ✔ .coverage-thresholds.json — {threshold}% coverage, enforcement: `{command}`
-  ✔ .claude/commands/   — 6 shims: start-task, prime, review-design, self-reflect, pr-shepherd, brainstorm
+  ✔ .claude/commands/   — Claude only: shims for start-task, prime, review-design, self-reflect, pr-shepherd, brainstorm
 
 Other files written:
   {list every other file written or modified with its path}
 
-You're all set! Run /start-task to begin working.
+You're all set! Run the platform's start command to begin working.
 ```
 
-**Command naming**: When recommending commands to the user, always use the short shim names (`/start-task`, `/prime`, `/brainstorm`, etc.), NOT the namespaced plugin names (`/metaswarm:start-task`). The shims you just created in `.claude/commands/` make the short names work. The short names are easier to type and remember.
+**Command naming**: When recommending commands to the user, use the active platform's names:
+- Claude Code: short shim names (`/start-task`, `/prime`, `/brainstorm`, etc.), NOT namespaced plugin names (`/metaswarm:start-task`)
+- Codex: skill names (`$start`, `$setup`, `$status`, `$pr-shepherd`)
+- Gemini: namespaced commands (`/metaswarm:start-task`, `/metaswarm:setup`)
 
 Offer 1-2 relevant tips based on configuration:
 - If external tools enabled: "Use `/external-tools-health` to check tool status."
@@ -419,9 +447,19 @@ If `/start-task` is invoked and `.metaswarm/project-profile.json` does not exist
 Before saying "setup complete", run this Bash command to verify the 3 mandatory files:
 
 ```bash
-echo "CLAUDE.md:"; grep -c "metaswarm" CLAUDE.md 2>/dev/null || echo "MISSING"; echo "coverage:"; ls .coverage-thresholds.json 2>/dev/null || echo "MISSING"; echo "shims:"; ls .claude/commands/start-task.md .claude/commands/prime.md .claude/commands/brainstorm.md 2>/dev/null || echo "MISSING"
+platform="${METASWARM_PLATFORM:-codex}"
+case "$platform" in
+  claude) instruction_file="CLAUDE.md" ;;
+  gemini) instruction_file="GEMINI.md" ;;
+  *) instruction_file="AGENTS.md" ;;
+esac
+echo "$instruction_file:"; grep -c "metaswarm" "$instruction_file" 2>/dev/null || echo "MISSING"
+echo "coverage:"; ls .coverage-thresholds.json 2>/dev/null || echo "MISSING"
+if [ "$platform" = "claude" ]; then
+  echo "shims:"; ls .claude/commands/start-task.md .claude/commands/prime.md .claude/commands/brainstorm.md 2>/dev/null || echo "MISSING"
+fi
 ```
 
 If any output says "MISSING", go back and run the setup-mandatory-files.sh script or create the files manually. Do NOT declare success with missing files.
 
-When reporting available commands to the user, use the **short names** (`/start-task`, `/prime`, `/brainstorm`, etc.) — NOT the namespaced names (`/metaswarm:start-task`). The command shims make the short names work. Do NOT recommend commands that don't exist (e.g., `/metaswarm:start`, `/metaswarm:status`, `/metaswarm:architect-agent`).
+When reporting available commands to the user, use the active platform's command style. Do NOT recommend commands that do not exist on that platform (for example, do not recommend Claude slash-command shims in Codex).

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -36,8 +36,8 @@ Where:
   - cargo → `"cargo tarpaulin --fail-under <threshold>"`
 - `<platform>` is `codex`, `claude`, `gemini`, or `all`. Prefer:
   - `codex` when running in Codex (`PLUGIN_ROOT` or `CODEX_HOME` is present, or the user invoked `$setup`)
-  - `claude` when running in Claude Code (`CLAUDE_PLUGIN_ROOT` is present, or the user invoked `/setup`)
-  - `gemini` when running in Gemini (`extensionPath` is present, or the user invoked `/metaswarm:setup`)
+  - `claude` when running in Claude Code (`CLAUDE_PLUGIN_ROOT` is present, or the setup skill was invoked there)
+  - `gemini` when running in Gemini (`extensionPath` is present, or the setup skill was invoked there)
   - `all` only when the user explicitly asks to configure every supported CLI
 
 The script handles:
@@ -241,6 +241,7 @@ bash "${PLUGIN_ROOT}/lib/setup-mandatory-files.sh" "$(pwd)" <threshold> "<covera
 ```
 
 Example for Codex with Python/pytest at 100%:
+
 ```bash
 bash "${PLUGIN_ROOT}/lib/setup-mandatory-files.sh" "$(pwd)" 100 "pytest --cov --cov-fail-under=100" --platform codex
 ```
@@ -414,13 +415,10 @@ Other files written:
 You're all set! Run the platform's start command to begin working.
 ```
 
-**Command naming**: When recommending commands to the user, use the active platform's names:
-- Claude Code: short shim names (`/start-task`, `/prime`, `/brainstorm`, etc.), NOT namespaced plugin names (`/metaswarm:start-task`)
-- Codex: skill names (`$start`, `$setup`, `$status`, `$pr-shepherd`)
-- Gemini: namespaced commands (`/metaswarm:start-task`, `/metaswarm:setup`)
+**Command naming**: When recommending metaswarm skills to the user, use `$name` forms (`$start`, `$setup`, `$status`, `$pr-shepherd`) unless the active platform has already created and selected its own command shims.
 
 Offer 1-2 relevant tips based on configuration:
-- If external tools enabled: "Use `/external-tools-health` to check tool status."
+- If external tools enabled: "Use `$external-tools` to check tool status."
 - If no CI set up: "Consider adding CI later -- metaswarm includes a template at `./templates/ci.yml`."
 - If visual review enabled: "The visual review skill will screenshot your app during development."
 
@@ -428,7 +426,7 @@ Offer 1-2 relevant tips based on configuration:
 
 ## Missing Setup Auto-Detection
 
-If `/start-task` is invoked and `.metaswarm/project-profile.json` does not exist, the start skill should auto-route here. This skill will run the full setup flow, then hand back to `/start-task` to continue with the user's original request.
+If `$start` is invoked and `.metaswarm/project-profile.json` does not exist, the start skill should auto-route here. This skill will run the full setup flow, then hand back to `$start` to continue with the user's original request.
 
 ---
 
@@ -447,11 +445,16 @@ If `/start-task` is invoked and `.metaswarm/project-profile.json` does not exist
 Before saying "setup complete", run this Bash command to verify the 3 mandatory files:
 
 ```bash
-platform="${METASWARM_PLATFORM:-codex}"
+platform="${METASWARM_PLATFORM:-${CLAUDE_PLUGIN_ROOT:+claude}}"
+platform="${platform:-${extensionPath:+gemini}}"
+platform="${platform:-${CODEX_HOME:+codex}}"
+platform="${platform:-${PLUGIN_ROOT:+codex}}"
+platform="${platform:-claude}"
 case "$platform" in
   claude) instruction_file="CLAUDE.md" ;;
   gemini) instruction_file="GEMINI.md" ;;
-  *) instruction_file="AGENTS.md" ;;
+  codex) instruction_file="AGENTS.md" ;;
+  *) echo "UNKNOWN PLATFORM: $platform"; exit 1 ;;
 esac
 echo "$instruction_file:"; grep -c "metaswarm" "$instruction_file" 2>/dev/null || echo "MISSING"
 echo "coverage:"; ls .coverage-thresholds.json 2>/dev/null || echo "MISSING"
@@ -462,4 +465,4 @@ fi
 
 If any output says "MISSING", go back and run the setup-mandatory-files.sh script or create the files manually. Do NOT declare success with missing files.
 
-When reporting available commands to the user, use the active platform's command style. Do NOT recommend commands that do not exist on that platform (for example, do not recommend Claude slash-command shims in Codex).
+When reporting available commands to the user, use `$name` skill invocation unless the active platform has its own confirmed command shims. Do NOT recommend commands that do not exist on that platform.

--- a/skills/start/references/codex-tools.md
+++ b/skills/start/references/codex-tools.md
@@ -1,12 +1,23 @@
-# Codex CLI Tool Mapping (Future)
+# Codex CLI Tool Mapping
 
 This file maps Claude Code tool names to Codex CLI equivalents.
-Implementation deferred — see `docs/plans/2026-02-26-plugin-migration-design.md` for details.
+Use these mappings when adapting metaswarm skills to run under Codex.
 
 | Claude Code Tool | Codex Equivalent |
 |------------------|------------------|
 | `Task()` | `spawn_agent` |
 | `Skill` | Native skills |
-| `Read` | `read_file` |
-| `Write` | `write_file` |
-| `Bash` | `shell` |
+| `Read` | `exec_command` with `sed`, `nl`, `rg`, or direct file tools when available |
+| `Write` | `apply_patch` for manual edits |
+| `Bash` | `exec_command` |
+| `/setup` | `$setup` |
+| `/start-task` | `$start` |
+| `/status` | `$status` |
+| `/pr-shepherd` | `$pr-shepherd` |
+
+## Codex Plugin Notes
+
+- Codex discovers metaswarm skills from `.codex-plugin/plugin.json` via `"skills": "./skills/"`.
+- Codex invokes skills by `SKILL.md` frontmatter name, not by directory name.
+- Codex plugin hooks are optional and require the `plugin_hooks` feature; core metaswarm workflows must work without hook context.
+- Prefer explicit setup/status checks over assuming SessionStart hooks ran.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -14,8 +14,8 @@ Generate a diagnostic report of the metaswarm installation, project configuratio
 Run each check below and present results in a single formatted report. Detect the active platform first:
 
 - Codex: `PLUGIN_ROOT` or `CODEX_HOME` is present, `.codex-plugin/plugin.json` is the active manifest, or the user invoked `$status`
-- Claude Code: `CLAUDE_PLUGIN_ROOT` is present, `.claude-plugin/plugin.json` is the active manifest, or the user invoked `/status`
-- Gemini: `extensionPath` is present, `gemini-extension.json` is the active manifest, or the user invoked `/metaswarm:status`
+- Claude Code: `CLAUDE_PLUGIN_ROOT` is present, `.claude-plugin/plugin.json` is the active manifest, or the user invoked `$status`
+- Gemini: `extensionPath` is present, `gemini-extension.json` is the active manifest, or the user invoked `$status`
 
 ### 1. Plugin Version
 
@@ -31,8 +31,8 @@ Run each check below and present results in a single formatted report. Detect th
 - If present, report key fields: `distribution`, `metaswarm_version`, `language`, `framework`, `test_runner`
 - If absent, report the platform-specific setup command:
   - Codex: `Project setup: NOT CONFIGURED -- run $setup`
-  - Claude Code: `Project setup: NOT CONFIGURED -- run /setup`
-  - Gemini: `Project setup: NOT CONFIGURED -- run /metaswarm:setup`
+  - Claude Code: `Project setup: NOT CONFIGURED -- run $setup`
+  - Gemini: `Project setup: NOT CONFIGURED -- run $setup`
 
 ### 3. Platform Install State
 

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -157,7 +157,7 @@ When issues are found:
 
 ```markdown
 ### Issues Found
-1. Legacy embedded plugin detected alongside marketplace plugin -- run `/migrate`
+1. Legacy embedded plugin detected alongside marketplace plugin -- run `$migrate`
 2. Codex plugin not installed from a marketplace -- install from `/plugins` after adding the marketplace
 
 ### Recommendations

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -5,17 +5,23 @@ description: Diagnostic status report — shows metaswarm installation state, pr
 
 # Status Skill
 
-Generate a diagnostic report of the metaswarm installation, project configuration, and potential issues. Useful for troubleshooting and verifying setup or migration.
+Generate a diagnostic report of the metaswarm installation, project configuration, and potential issues across Claude Code, Codex, and Gemini. Useful for troubleshooting and verifying setup or migration.
 
 ---
 
 ## Checks
 
-Run each check below and present results in a single formatted report.
+Run each check below and present results in a single formatted report. Detect the active platform first:
+
+- Codex: `PLUGIN_ROOT` or `CODEX_HOME` is present, `.codex-plugin/plugin.json` is the active manifest, or the user invoked `$status`
+- Claude Code: `CLAUDE_PLUGIN_ROOT` is present, `.claude-plugin/plugin.json` is the active manifest, or the user invoked `/status`
+- Gemini: `extensionPath` is present, `gemini-extension.json` is the active manifest, or the user invoked `/metaswarm:status`
 
 ### 1. Plugin Version
 
-- Read `.claude-plugin/plugin.json` from the plugin root -- report the `version` field
+- Codex: read `.codex-plugin/plugin.json` from the plugin root and report `version`
+- Claude Code: read `.claude-plugin/plugin.json` from the plugin root and report `version`
+- Gemini: read `gemini-extension.json` from the plugin root and report `version`
 - Fallback: read `package.json` at plugin root for `version`
 - If neither found: `Plugin version: UNKNOWN`
 
@@ -23,11 +29,31 @@ Run each check below and present results in a single formatted report.
 
 - Check if `.metaswarm/project-profile.json` exists in the working directory
 - If present, report key fields: `distribution`, `metaswarm_version`, `language`, `framework`, `test_runner`
-- If absent: `Project setup: NOT CONFIGURED -- run /metaswarm:setup`
+- If absent, report the platform-specific setup command:
+  - Codex: `Project setup: NOT CONFIGURED -- run $setup`
+  - Claude Code: `Project setup: NOT CONFIGURED -- run /setup`
+  - Gemini: `Project setup: NOT CONFIGURED -- run /metaswarm:setup`
 
-### 3. Command Shims
+### 3. Platform Install State
 
-Check these 6 files in `.claude/commands/`:
+**Codex**
+- Check `.codex-plugin/plugin.json` exists in the plugin root
+- Check `~/.codex/config.toml` for an enabled `metaswarm@...` plugin entry when accessible
+- Scan `~/.codex/plugins/cache/` for `.codex-plugin/plugin.json` with `"name": "metaswarm"`
+- If installed from a local marketplace, report cache version as `local`
+
+**Claude Code**
+- Check `.claude-plugin/plugin.json` exists in the plugin root
+- Scan `~/.claude/plugins/cache/` for `.claude-plugin/plugin.json` with `"name": "metaswarm"`
+- Report marketplace/plugin cache status when accessible
+
+**Gemini**
+- Check `gemini-extension.json` exists in the plugin root
+- Report extension status when discoverable from the local Gemini config
+
+### 4. Claude Command Shims
+
+When checking a Claude project, check these files in `.claude/commands/`:
 
 | Shim | Expected |
 |---|---|
@@ -40,19 +66,21 @@ Check these 6 files in `.claude/commands/`:
 
 For each: report Present/Missing. If the file exists but does not contain "metaswarm" routing, flag as `present (non-metaswarm content)`.
 
-### 4. Legacy Embedded Plugin
+When checking a Codex project, report `not applicable (Codex uses $skill-name invocation)` instead of treating missing `.claude/commands/` files as errors.
+
+### 5. Legacy Embedded Plugin
 
 - Check for `.claude/plugins/metaswarm/.claude-plugin/plugin.json`
 - If found: `DETECTED -- run /metaswarm:migrate`
 - If found alongside the marketplace plugin, flag prominently as a conflict
 
-### 5. BEADS Plugin
+### 6. BEADS Plugin
 
-- Scan `~/.claude/plugins/cache/` for a directory containing `.claude-plugin/plugin.json` with `"name": "beads"`
+- Scan `~/.claude/plugins/cache/` and `~/.codex/plugins/cache/` for a directory containing `.claude-plugin/plugin.json` or `.codex-plugin/plugin.json` with `"name": "beads"`
 - If found: `installed (standalone)` -- metaswarm defers priming to BEADS
 - If not found: `not separately installed`
 
-### 6. `bd` CLI
+### 7. `bd` CLI
 
 ```bash
 command -v bd && bd --version 2>/dev/null
@@ -61,7 +89,16 @@ command -v bd && bd --version 2>/dev/null
 - If found: report path and version
 - If not found: `not installed -- knowledge priming and self-reflect require bd. Core orchestration works without it.`
 
-### 7. External Tools
+### 8. `gtg` CLI
+
+```bash
+command -v gtg && gtg --help >/dev/null 2>&1
+```
+
+- If found: report path
+- If not found: `not installed -- pr-shepherd will fall back to manual gh checks.`
+
+### 9. External Tools
 
 - Read `.metaswarm/external-tools.yaml` -- if absent: `not configured (optional)`
 - If present, check each enabled adapter's availability:
@@ -73,12 +110,12 @@ command -v gemini   # Gemini CLI
 
 Report per-tool: enabled (yes/no), status (available/not installed).
 
-### 8. Coverage Thresholds
+### 10. Coverage Thresholds
 
 - Read `.coverage-thresholds.json` -- if absent: `not configured`
 - If present, report threshold values (lines, branches, functions, statements) and enforcement command
 
-### 9. Node.js
+### 11. Node.js
 
 ```bash
 node --version 2>/dev/null
@@ -96,12 +133,15 @@ node --version 2>/dev/null
 
 | Component | Status |
 |---|---|
-| Plugin version | 1.0.0 |
+| Active platform | Codex |
+| Plugin version | 0.11.0 |
 | Project setup | Configured (distribution: plugin) |
-| Command shims | 6/6 present |
+| Platform install | Codex plugin installed and enabled |
+| Command shims | Not applicable (Codex uses $skill-name) |
 | Legacy embedded plugin | Not detected |
 | BEADS plugin | Not separately installed |
 | bd CLI | Available (v0.5.2) |
+| gtg CLI | Available |
 | External tools | Codex: available, Gemini: not installed |
 | Coverage thresholds | 100% (all categories) |
 | Node.js | Available (v22.4.0) |
@@ -117,16 +157,17 @@ When issues are found:
 
 ```markdown
 ### Issues Found
-1. Legacy embedded plugin detected alongside marketplace plugin -- run `/metaswarm:migrate`
-2. Command shim `start-task.md` missing -- run `/metaswarm:setup`
+1. Legacy embedded plugin detected alongside marketplace plugin -- run `/migrate`
+2. Codex plugin not installed from a marketplace -- install from `/plugins` after adding the marketplace
 
 ### Recommendations
 1. Install `bd` CLI for knowledge priming and self-reflect
-2. Configure external tools for cross-model review (`.metaswarm/external-tools.yaml`)
+2. Install `gtg` for the fastest `$pr-shepherd` readiness checks
+3. Configure external tools for cross-model review (`.metaswarm/external-tools.yaml`)
 ```
 
 ---
 
 ## Error Handling
 
-This skill is diagnostic-only and never fails fatally. If any individual check errors, report the failure for that check (e.g., `Plugin version: ERROR -- could not read plugin.json`) and continue with remaining checks.
+This skill is diagnostic-only and never fails fatally. If any individual check errors, report the failure for that check (for example, `Plugin version: ERROR -- could not read plugin.json`) and continue with remaining checks.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -71,7 +71,7 @@ When checking a Codex project, report `not applicable (Codex uses $skill-name in
 ### 5. Legacy Embedded Plugin
 
 - Check for `.claude/plugins/metaswarm/.claude-plugin/plugin.json`
-- If found: `DETECTED -- run /metaswarm:migrate`
+- If found: `DETECTED -- run $migrate`
 - If found alongside the marketplace plugin, flag prominently as a conflict
 
 ### 6. BEADS Plugin

--- a/tests/hooks/test-session-start.sh
+++ b/tests/hooks/test-session-start.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 HOOK_SCRIPT="$SCRIPT_DIR/../../hooks/session-start.sh"
 PASS=0
 FAIL=0
@@ -52,6 +53,32 @@ assert_not_contains() {
   fi
 }
 
+assert_file_exists() {
+  local desc="$1"
+  local file="$2"
+  TOTAL=$((TOTAL + 1))
+  if [ -f "$file" ]; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc — expected file: $file"
+  fi
+}
+
+assert_file_not_exists() {
+  local desc="$1"
+  local file="$2"
+  TOTAL=$((TOTAL + 1))
+  if [ -e "$file" ]; then
+    FAIL=$((FAIL + 1))
+    echo "  FAIL: $desc — should NOT exist: $file"
+  else
+    PASS=$((PASS + 1))
+    echo "  PASS: $desc"
+  fi
+}
+
 # --- Test setup ---
 TMPDIR_BASE=$(mktemp -d)
 trap "rm -rf $TMPDIR_BASE" EXIT
@@ -65,7 +92,7 @@ TEST_CWD="$TMPDIR_BASE/test1"
 mkdir -p "$TEST_CWD"
 output=$(cd "$TEST_CWD" && bash "$HOOK_SCRIPT" 2>/dev/null || true)
 assert_json_valid "Output is valid JSON" "$output"
-assert_contains "Contains setup nudge" "$output" "metaswarm:setup"
+assert_contains "Contains setup nudge" "$output" '$setup'
 
 # --- Test 2: Configured project (has .metaswarm/project-profile.json) ---
 echo "Test 2: Configured project"
@@ -74,7 +101,29 @@ mkdir -p "$TEST_CWD/.metaswarm"
 echo '{"distribution":"plugin"}' > "$TEST_CWD/.metaswarm/project-profile.json"
 output=$(cd "$TEST_CWD" && bash "$HOOK_SCRIPT" 2>/dev/null || true)
 assert_json_valid "Output is valid JSON" "$output"
-assert_not_contains "No setup nudge" "$output" "metaswarm:setup"
+assert_not_contains "No setup nudge" "$output" '$setup'
+
+# --- Test 2b: Codex self-heal writes Codex files only ---
+echo "Test 2b: Codex self-heal is platform-aware"
+TEST_CWD="$TMPDIR_BASE/test2b"
+mkdir -p "$TEST_CWD/.metaswarm"
+echo '{"distribution":"plugin","coverage":{"threshold":93},"commands":{"coverage":"npm test -- --coverage"}}' > "$TEST_CWD/.metaswarm/project-profile.json"
+output=$(cd "$TEST_CWD" && PLUGIN_ROOT="$REPO_ROOT" bash "$HOOK_SCRIPT" 2>/dev/null || true)
+assert_json_valid "Output is valid JSON" "$output"
+assert_file_exists "Creates AGENTS.md" "$TEST_CWD/AGENTS.md"
+assert_file_exists "Creates coverage thresholds" "$TEST_CWD/.coverage-thresholds.json"
+assert_file_not_exists "Does not create Claude shims" "$TEST_CWD/.claude/commands/start-task.md"
+
+# --- Test 2c: Claude self-heal still writes Claude command shims ---
+echo "Test 2c: Claude self-heal keeps Claude support"
+TEST_CWD="$TMPDIR_BASE/test2c"
+mkdir -p "$TEST_CWD/.metaswarm"
+echo '{"distribution":"plugin","coverage":{"threshold":88},"commands":{"coverage":"npm test -- --coverage"}}' > "$TEST_CWD/.metaswarm/project-profile.json"
+output=$(cd "$TEST_CWD" && CLAUDE_PLUGIN_ROOT="$REPO_ROOT" bash "$HOOK_SCRIPT" 2>/dev/null || true)
+assert_json_valid "Output is valid JSON" "$output"
+assert_file_exists "Creates CLAUDE.md" "$TEST_CWD/CLAUDE.md"
+assert_file_exists "Creates Claude command shims" "$TEST_CWD/.claude/commands/start-task.md"
+assert_file_exists "Creates coverage thresholds" "$TEST_CWD/.coverage-thresholds.json"
 
 # --- Test 3: Legacy install detection ---
 echo "Test 3: Legacy install detection"
@@ -85,7 +134,7 @@ mkdir -p "$TEST_CWD/.metaswarm"
 echo '{"distribution":"npm"}' > "$TEST_CWD/.metaswarm/project-profile.json"
 output=$(cd "$TEST_CWD" && bash "$HOOK_SCRIPT" 2>/dev/null || true)
 assert_json_valid "Output is valid JSON" "$output"
-assert_contains "Contains migrate message" "$output" "metaswarm:migrate"
+assert_contains "Contains migrate message" "$output" '$migrate'
 
 # --- Test 4: BEADS dedup detection ---
 echo "Test 4: BEADS dedup detection"

--- a/tests/hooks/test-session-start.sh
+++ b/tests/hooks/test-session-start.sh
@@ -92,7 +92,25 @@ TEST_CWD="$TMPDIR_BASE/test1"
 mkdir -p "$TEST_CWD"
 output=$(cd "$TEST_CWD" && bash "$HOOK_SCRIPT" 2>/dev/null || true)
 assert_json_valid "Output is valid JSON" "$output"
-assert_contains "Contains setup nudge" "$output" '$setup'
+assert_contains "Contains Claude setup nudge" "$output" '/setup'
+
+# --- Test 1b: Codex new project uses Codex skill names ---
+echo "Test 1b: Codex new project command names"
+TEST_CWD="$TMPDIR_BASE/test1b"
+mkdir -p "$TEST_CWD"
+output=$(cd "$TEST_CWD" && PLUGIN_ROOT="$REPO_ROOT" bash "$HOOK_SCRIPT" 2>/dev/null || true)
+assert_json_valid "Output is valid JSON" "$output"
+assert_contains "Contains Codex setup nudge" "$output" '$setup'
+assert_contains "Contains Codex start nudge" "$output" '$start'
+
+# --- Test 1c: Gemini new project uses Gemini command names ---
+echo "Test 1c: Gemini new project command names"
+TEST_CWD="$TMPDIR_BASE/test1c"
+mkdir -p "$TEST_CWD"
+output=$(cd "$TEST_CWD" && extensionPath="$REPO_ROOT" bash "$HOOK_SCRIPT" 2>/dev/null || true)
+assert_json_valid "Output is valid JSON" "$output"
+assert_contains "Contains Gemini setup nudge" "$output" '/metaswarm:setup'
+assert_contains "Contains Gemini start nudge" "$output" '/metaswarm:start-task'
 
 # --- Test 2: Configured project (has .metaswarm/project-profile.json) ---
 echo "Test 2: Configured project"
@@ -101,7 +119,7 @@ mkdir -p "$TEST_CWD/.metaswarm"
 echo '{"distribution":"plugin"}' > "$TEST_CWD/.metaswarm/project-profile.json"
 output=$(cd "$TEST_CWD" && bash "$HOOK_SCRIPT" 2>/dev/null || true)
 assert_json_valid "Output is valid JSON" "$output"
-assert_not_contains "No setup nudge" "$output" '$setup'
+assert_not_contains "No setup nudge" "$output" '/setup'
 
 # --- Test 2b: Codex self-heal writes Codex files only ---
 echo "Test 2b: Codex self-heal is platform-aware"
@@ -134,7 +152,7 @@ mkdir -p "$TEST_CWD/.metaswarm"
 echo '{"distribution":"npm"}' > "$TEST_CWD/.metaswarm/project-profile.json"
 output=$(cd "$TEST_CWD" && bash "$HOOK_SCRIPT" 2>/dev/null || true)
 assert_json_valid "Output is valid JSON" "$output"
-assert_contains "Contains migrate message" "$output" '$migrate'
+assert_contains "Contains Claude migrate message" "$output" '/migrate'
 
 # --- Test 4: BEADS dedup detection ---
 echo "Test 4: BEADS dedup detection"


### PR DESCRIPTION
## Summary
- add a first-class Codex plugin manifest and repo marketplace metadata
- update Codex install docs to use plugin marketplace flow while keeping legacy symlink fallback
- make setup/status behavior platform-aware so Codex uses AGENTS.md and Claude keeps CLAUDE.md plus command shims

## Validation
- node lib/sync-resources.js --check
- manifest JSON parse for package, Claude, Codex, Gemini, and Codex marketplace files
- git diff --check
- CODEX_HOME=/private/tmp/metaswarm-codex-marketplace-final codex plugin marketplace add /Users/dsifry/Developer/metaswarm
- CODEX_HOME=/private/tmp/metaswarm-codex-remote-marketplace codex plugin marketplace add dsifry/metaswarm-marketplace
- isolated authenticated Codex exec session saw metaswarm skills including setup, start, status, and pr-shepherd
- setup-mandatory-files.sh smoke verified Codex writes AGENTS.md without Claude shims and Claude still writes CLAUDE.md plus shims

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes cross-platform install detection and hook-driven self-healing logic (including writing instruction files) based on inferred platform; mistakes could cause incorrect files to be created or skipped in user projects.
> 
> **Overview**
> Adds **first-class Codex plugin distribution** by introducing a `.codex-plugin/plugin.json` manifest and a Codex marketplace definition at `.agents/plugins/marketplace.json`.
> 
> Updates installation/docs to prefer the Codex plugin marketplace flow (with legacy clone+symlink fallback) and adds a dedicated Codex integration doc.
> 
> Makes setup/status flows **platform-aware**: `lib/platform-detect.js` now treats Codex as plugin-installed; `lib/setup-mandatory-files.sh` and `hooks/session-start.sh` select the correct instruction file (`AGENTS.md` vs `CLAUDE.md`/`GEMINI.md`), only create Claude command shims when appropriate, and emit platform-specific command nudges. Validation in `lib/sync-resources.js`, the `status` prompts, and hook tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13581699bc81f8cc9202ff5299fc1361ef97b123. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->