### PR TITLE
Normalize Codex skill discovery metadata

### DIFF
--- a/skills/brainstorming-extension/SKILL.md
+++ b/skills/brainstorming-extension/SKILL.md
@@ -1,10 +1,6 @@
 ---
 name: brainstorming-extension
-description: Enforces design review gate after brainstorming — bridges superpowers:brainstorming into the metaswarm quality pipeline
-auto_activate: true
-triggers:
-  - after:superpowers:brainstorming
-  - "design document committed"
+description: Enforce the design review gate after brainstorming or design-document creation; use when brainstorming completes, a design document is committed, or metaswarm needs to bridge brainstorming into the review pipeline.
 ---
 
 # Brainstorming Extension - Mandatory Review Gate Bridge

--- a/skills/design-review-gate/SKILL.md
+++ b/skills/design-review-gate/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: design-review-gate
-description: Automatic review gate that runs after brainstorming completes - spawns PM, Architect, Designer, Security, and CTO agents in parallel, iterates until all approve
-auto_activate: true
-triggers:
-  - "design document created"
-  - "docs/plans/*-design.md committed"
-  - after:superpowers:brainstorming
+description: Run a mandatory multi-reviewer design gate; use after brainstorming, when a design document is created or committed, or before implementation planning for multi-file, workflow, UX, architecture, or security-impacting changes.
 ---
 
 # Design Review Gate

--- a/skills/external-tools/SKILL.md
+++ b/skills/external-tools/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: external-tools
-description: Delegate implementation and review tasks to external AI CLI tools (Codex, Gemini) with cross-model adversarial review
-auto_activate: false
-triggers:
-  - "use external tools"
-  - "delegate to codex"
-  - "delegate to gemini"
-  - "cross-model review"
+description: Delegate implementation or review work to external AI CLI tools such as Codex or Gemini; use when asked to use external tools, delegate to Codex or Gemini, or run cross-model adversarial review.
 ---
 
 # External Tools Skill

--- a/skills/orchestrated-execution/SKILL.md
+++ b/skills/orchestrated-execution/SKILL.md
@@ -1,11 +1,6 @@
 ---
 name: orchestrated-execution
-description: 4-phase execution loop for work units - IMPLEMENT, VALIDATE, ADVERSARIAL REVIEW, COMMIT
-auto_activate: false
-triggers:
-  - "orchestrated execution"
-  - "4-phase loop"
-  - "adversarial review"
+description: Run the metaswarm 4-phase execution loop for work units; use when asked for orchestrated execution, GSD-style implementation, adversarial review, or explicit implement-validate-review-commit delivery.
 ---
 
 # Orchestrated Execution Skill

--- a/skills/plan-review-gate/SKILL.md
+++ b/skills/plan-review-gate/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: plan-review-gate
-description: Automatic adversarial review gate that spawns 3 independent reviewers in parallel after any plan is drafted - all must PASS before presenting to user
-auto_activate: true
-triggers:
-  - "plan drafted"
-  - "implementation plan created"
-  - after:writing-plans
-  - after:orchestrated-execution:plan-validation
+description: Run an adversarial plan review gate with three independent reviewers; use after drafting an implementation plan, before presenting a plan as approved, or when asked for plan-review validation.
 ---
 
 # Plan Review Gate

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: start
-description: Use when starting work on any task, when the user mentions metaswarm, or when the user wants to begin tracked development work
-auto_activate: true
-triggers:
-  - "work on issue"
-  - "start issue"
-  - "start task"
-  - "use metaswarm"
-  - "@metaswarm"
-  - "agent-ready label"
+description: Begin tracked metaswarm or BEADS work; use when starting work on an issue or task, when the user mentions metaswarm, or when agent-ready or GSD-style development should enter the workflow.
 ---
 
 # BEADS Multi-Agent Orchestration Skill

--- a/skills/visual-review/SKILL.md
+++ b/skills/visual-review/SKILL.md
@@ -1,15 +1,6 @@
 ---
 name: visual-review
-description: Take screenshots of web pages and UI using Playwright for visual review and iteration
-auto_activate: false
-triggers:
-  - "visual review"
-  - "screenshot"
-  - "take a screenshot"
-  - "review visually"
-  - "check how it looks"
-  - "review the UI"
-  - "review the slides"
+description: Take Playwright screenshots of web pages, slides, or UI for visual review and iteration; use when asked to screenshot, visually inspect, review UI or slides, or check how a local or deployed page looks.
 ---
 
 # Visual Review


### PR DESCRIPTION
## What
- normalize Codex discovery metadata in seven metaswarm skills
- remove unsupported `auto_activate` and `triggers` frontmatter keys
- preserve trigger intent in each skill description

## Why
Codex discovers skills from the `name` and `description` fields. Keeping trigger guidance in unsupported frontmatter creates drift without affecting discovery.

## Validation
- PASS: `C:\Program Files\Git\bin\bash.exe tests/codex/test-codex-skills.sh` (36 passed, 0 failed)
- PASS: all 13 `skills/*/SKILL.md` files contain valid discovery metadata
- NOTE: `node lib/sync-resources.js --check` reports 12 pre-existing generated command TOML drifts outside this seven-file skill scope; those files were intentionally not modified